### PR TITLE
Fix #47; More generic regex for fq files.

### DIFF
--- a/bin/generate_sample_sheet.py
+++ b/bin/generate_sample_sheet.py
@@ -23,16 +23,16 @@ import re
 import yaml
 
 
-fq_pattern = re.compile("(.*)_R(1|2).*")
+fq_pattern = re.compile("(.*)_R?(1|2)\.f(ast)?q(\.gz)?")
 
 
 def main(args):
     assert args.dir.is_dir(), "Argument must be a directory."
     
-    files = list(args.dir.glob("*_R?*.f*q"))
-
     samples = {}
-    for file_ in files:
+    for file_ in args.dir.iterdir():
+        if file_.is_dir():
+            continue
         match = fq_pattern.fullmatch(file_.name)
         sample = samples.setdefault(match.group(1), {})
         sample["R{}".format(match.group(2))] = str(file_)


### PR DESCRIPTION
Changes to generate_sample_sheet.py:
* Remove separate glob pattern for fq files.
* Adjust regex pattern to match 'fq' and 'fastq' file extensions and
  gzipped files, with or without 'R'.

Fixes #47