### PR TITLE
Mapped reads

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -625,7 +625,7 @@ rule count_mapped_reads:
     output:
         "results/Mapped_read_counts.tsv"
     conda:
-        "envs/scaffolds_analyses.yaml"
+        "envs/scaffold_analyses.yaml"
     benchmark:
         "logs/benchmark/count_mapped_reads.txt"
     threads: 1

--- a/Snakefile
+++ b/Snakefile
@@ -619,6 +619,25 @@ ktImportTaxonomy {input} -i -k -m 4 -o {output} > {log} 2>&1
     ##### Count annotated reads and visualise as stacked bar charts         #####
     #############################################################################
         
+rule count_mapped_reads:
+    input:
+        expand("data/scaffolds_filtered/{sample}_sorted.bam", sample = SAMPLES)
+    output:
+        "results/Mapped_read_counts.tsv"
+    conda:
+        "envs/scaffolds_analyses.yaml"
+    benchmark:
+        "logs/benchmark/count_mapped_reads.txt"
+    threads: 1
+    log:
+        "logs/count_mapped_reads.txt"
+    params:
+        input_dir="data/scaffolds_filtered/"
+    shell:
+        """
+bash bin/count_mapped_reads.sh {params.input_dir} > {output} 2> {log}
+        """
+
 rule quantify_output:
     input:
         fastqc = "results/multiqc_data/multiqc_fastqc.txt",
@@ -627,7 +646,8 @@ rule quantify_output:
                       sample = set(SAMPLES),
                       suffix = [ "pR1", "pR2", "unpaired" ]),
         classified = "results/all_taxClassified.tsv",
-        unclassified = "results/all_taxUnclassified.tsv"
+        unclassified = "results/all_taxUnclassified.tsv",
+        mapped_reads = "results/Mapped_read_counts.tsv"
     output:
         counts = "results/profile_read_counts.csv",
         percentages = "results/profile_percentages.csv",
@@ -647,6 +667,7 @@ python bin/quantify_profiles.py \
 -hg {input.hugo} \
 -c {input.classified} \
 -u {input.unclassified} \
+-m {input.mapped_reads} \
 -co {output.counts} \
 -p {output.percentages} \
 -g {output.graph} \

--- a/bin/count_mapped_reads.sh
+++ b/bin/count_mapped_reads.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+# Script to count reads mapped to contigs,
+# counting ONLY PRIMARY alignments and 
+# NO SUPPLEMENTARY alignments.
+
+# Returns counts as a table with two columns:
+# 'scaffold_name' and 'mapped_reads'
+# (for merging with all_taxClassified.tsv and
+# all_taxUnclassified.tsv in bin/quantify_output.py).
+
+INPUT_FOLDER=$1
+BAM_FILES="${INPUT_FOLDER}/*_sorted.bam"
+RESULT_FILE=$2
+
+printf "mapped_reads\tscaffold_name\n" #> $RESULT_FILE
+# have the complete script redirect ouput to a file (and log file?)
+
+for file in $BAM_FILES
+do
+    paired_mapped_reads=$(samtools view -F 4 -F 8 -F 256 -F 2048 $file | cut -f 3 | sort | uniq -c | sed $"s/NODE_/\tNODE_/g")
+    #cut the contig names, sort and count, and place tabs between numbers and contigs names
+    unpaired_mapped_reads=$(samtools view -F 4 -f 8 -F 256 -F 2048 $file | cut -f 3 | sort | uniq -c | sed $"s/NODE_/\tNODE_/g")
+    mapped_reads=$(samtools view -F 4 -F 256 -F 2048 $file | cut -f 3 | sort | uniq -c | sed $"s/NODE_/\tNODE_/g")
+    #mapped_reads = both paired and unpaired! (do not filter for paired or not = 8)
+    samtools view -F 4 -F 256 -F 2048 $file | cut -f 3 | sort | uniq -c | sed $"s/NODE_/\tNODE_/g"
+done

--- a/bin/quantify_profiles.py
+++ b/bin/quantify_profiles.py
@@ -8,6 +8,8 @@ Date: 4 December 2018
 -- 21 May 2019 update: start complete rework to make the script snakemake-independent and fix bugs
         N.B. For now, the number of threads is still passed by snakemake!
           It can optionally be provided as command-line argument.
+-- 19 Sep 2019 update: count mapped reads with separate script (with samtools view)
+        merge these reads to all_tax[Un]classified.tsv for correct quantifications
 
 Script that gathers numbers from the PZN analysis, i.e.:
  - number of reads per sample (raw)
@@ -76,9 +78,14 @@ def parse_arguments():
     Parse the arguments from the command line, i.e.:
      -f/--fastqc = file with (multiqc) fastqc output
      -t/--trimmomatic = file with (multiqc) trimmomatic output
-     -h/--hugo = fastq files of extracted human reads
+     -hg/--hugo = fastq files of extracted human reads
      -c/--classified = table with taxonomic classifications
      -u/--unclassified = table with unclassified contigs
+     -m/--mapped_reads = table with number of mapped reads
+     -co/--counts = output file (table) with counts
+     -pg/--percentages = output file (table) with percentages
+     -cpu/--cpu-cores = number of cores (threads) to use
+     -col/--colours = colours to use in figure/barchart (8 colours)
      -h/--help = show help
     """
     parser = argparse.ArgumentParser(prog="draw heatmaps",
@@ -129,6 +136,14 @@ def parse_arguments():
                           required=True,
                           type=str,
                           help="Table with unclassified contigs")
+
+    required.add_argument('-m',
+                          '--mapped-reads',
+                          dest="mapped_reads",
+                          metavar='',
+                          required=True,
+                          type=str,
+                          help="Table with mapped read counts")
 
     required.add_argument('-co',
                           '--counts',
@@ -273,7 +288,7 @@ def count_non_human_reads(file_list, threads):
     
     return(read_df)
 
-def sum_superkingdoms(classified_file):
+def sum_superkingdoms(classified_file, mapped_reads_file):
     """
     Input:
         taxonomic classifications and quantifications as
@@ -284,16 +299,21 @@ def sum_superkingdoms(classified_file):
         that were not assigned a superkingdom ("not classified")
     """
     clas_df = pd.read_csv(classified_file, delimiter = '\t')
-    #Sum the forward and reverse reads per classified scaffold:
-    clas_df["reads"] = clas_df.Plus_reads + clas_df.Minus_reads
+    
+    counts_df = pd.read_csv(mapped_reads_file, delimiter = '\t')
+    clas_df = pd.merge(clas_df, counts_df, how = 'left', on = 'scaffold_name')
+    #If a scaffold has no reads mapping to it, set to 0:
+    clas_df.fillna({"mapped_reads" : 0}, inplace=True)
+
     # N.B. Take into account reads that were not assigned a superkingdom
     # and are therefore actually still unclassified!
     clas_df.fillna("not classified", inplace=True)
+
     #Count the reads assigned to Archaea, Bacteria, Eukaryota and Viruses per sample:
     superkingdom_sums = pd.DataFrame(clas_df.groupby(
     [ "Sample_name", "superkingdom" ]).sum()
-                         [[ "reads" ]])
-    
+                         [[ "mapped_reads" ]])
+
     #Check all samples and superkingdoms to find out for which superkingdoms there is no data
     samples_superkingdoms_dict = {}
     for i in superkingdom_sums.index:
@@ -310,7 +330,7 @@ def sum_superkingdoms(classified_file):
     for key, value in samples_superkingdoms_dict.items():
         for superkingdom in [ "Archaea", "Bacteria", "Eukaryota", "Viruses", "not classified" ]:
             if superkingdom not in value:
-                newdata.loc[(key, superkingdom), "reads"] = 0
+                newdata.loc[(key, superkingdom), "mapped_reads"] = 0
             else:
                 pass
     
@@ -325,12 +345,12 @@ def sum_superkingdoms(classified_file):
     final_df = pd.DataFrame(
         new_df.pivot(index = "Sample_name",
                       columns="superkingdom",
-                                values="reads"))
+                                values="mapped_reads"))
     final_df.reset_index(inplace=True)
     
     return(final_df)
 
-def sum_unclassified(unclassified_file):
+def sum_unclassified(unclassified_file, mapped_reads_file):
     """
     Input:
         table of scaffolds that were not classified by PZN
@@ -340,11 +360,13 @@ def sum_unclassified(unclassified_file):
         unclassified scaffolds per sample
     """
     unclas_df = pd.read_csv(unclassified_file, delimiter = '\t')
-    #Sum the forward and reverse reads per unclassified scaffold:
-    unclas_df["reads"] = unclas_df.Plus_reads + unclas_df.Minus_reads
+
+    counts_df = pd.read_csv(mapped_reads_file, delimiter = '\t')
+    unclas_df = pd.merge(unclas_df, counts_df, how = 'left', on = 'scaffold_name')
+
     # Summarise the reads per sample:
     unclas_sums = pd.DataFrame(unclas_df.groupby("Sample_name").sum()
-                               [[ "reads" ]])
+                               [[ "mapped_reads" ]])
     unclas_sums.reset_index(inplace=True)
     
     return(unclas_sums)
@@ -506,18 +528,20 @@ def main():
                 "hugo = {2}\n"
                 "classified = {3}\n"
                 "unclassified: {4}\n"
+                "mapped_reads: {5}\n"
                 "  OUTPUT:\n"
-                "counts = {5}\n"
-                "percentages = {6}\n"
-                "graph = {7}\n"
+                "counts = {6}\n"
+                "percentages = {7}\n"
+                "graph = {8}\n"
                 "  OPTIONAL:\n"
-                "log = {8}\n"
-                "cores = {9}\n"
-                "colours = {10}".format(arguments.fastqc,
+                "log = {9}\n"
+                "cores = {10}\n"
+                "colours = {11}".format(arguments.fastqc,
                                         arguments.trimmomatic,
                                         arguments.hugo,
                                         arguments.classified,
                                         arguments.unclassified,
+                                        arguments.mapped_reads,
                                         arguments.counts,
                                         arguments.percentages,
                                         arguments.graph,
@@ -623,7 +647,7 @@ def main():
     ## (Minimap reads to scaffolds > 500 nt long from SPAdes,
     ## that have been classified with Megablast to BLAST nt database
     ## and the LCA algorithm from Krona (see PZN methods).)
-    classified_nrs = sum_superkingdoms(arguments.classified)
+    classified_nrs = sum_superkingdoms(arguments.classified, arguments.mapped_reads)
     
     #Debug:
     #print(classified_nrs.head())
@@ -631,7 +655,7 @@ def main():
     #6. Reads mapped to unclassified scaffolds/sample:
     ## (Minimap reads to scaffolds that Megablast could not
     ## assign.)
-    unclassified_nrs = sum_unclassified(arguments.unclassified)
+    unclassified_nrs = sum_unclassified(arguments.unclassified, arguments.mapped_reads)
     
     #Debug:
     #print(unclassified_nrs.head())
@@ -651,7 +675,7 @@ def main():
     # from the 'unclassified contigs table' and those from
     # the 'classified contigs table' that wern not assigned
     # a superkingdom:
-    nrs_df["Unclassified"] = nrs_df.reads + nrs_df["not classified"]
+    nrs_df["Unclassified"] = nrs_df.mapped_reads + nrs_df["not classified"]
 
     #And keep only the relevant columns,
     # in a logical order:

--- a/bin/quantify_profiles.py
+++ b/bin/quantify_profiles.py
@@ -221,8 +221,11 @@ def count_sequences_in_fastq(infile):
     with open(infile, 'r') as f:
         for i, l in enumerate(f):
             pass
-    lines = i + 1
-    return(lines / 4)
+    try:
+        lines = i + 1
+        return(lines / 4)
+    except UnboundLocalError: #happens when file is empty, there is no 'i'
+        return(0)
 
 def progress(count, total, status=''):
     """


### PR DESCRIPTION
Issues with counting (mapped) reads should all be closed now (#56 -> https://github.com/DennisSchmitz/Jovian/commit/61c823ba5e9e9efa12a8bbc0dfd7c3c0021502f9 and #57 -> https://github.com/DennisSchmitz/Jovian/commit/9001b0a90664ba13e3814340beba19bb852e41b8 and  #59 -> https://github.com/DennisSchmitz/Jovian/commit/1e0702fddb7cc83e9cf1d35c87e984f9800727c5). `bin/quantify_profiles.py` is now more robust to empty fastq files of non-human reads, uses RegEx to better handle file names, and no longer creates bar charts with negative numbers of 'remaining reads' and percentages over 100%.