### PR TITLE
Fix support for dashes in sample name

### DIFF
--- a/bin/concatenate_mapped_read_counts.py
+++ b/bin/concatenate_mapped_read_counts.py
@@ -80,7 +80,15 @@ def main():
     concat_df = pd.DataFrame()
     
     for file in arguments.input:
-        sample = os.path.splitext(file.split('-')[-1])[0]
+        if file.count('-') > 1:
+            #If there are multiple dashes in the file name, the
+            # sample name contains one or more dashes.
+            sample = os.path.splitext('-'.join(file.split('-')[1:]))[0]
+            #So sample should include all parts separated by dashes.
+        else:
+            #Otherwise, the sample name has no dashes and splitting
+            # the filename in two will work.
+            sample = os.path.splitext(file.split('-')[-1])[0]
         df = pd.read_csv(file, sep='\t')
         df["Sample_name"] = sample
         


### PR DESCRIPTION
The mapped read count concatenation script was not prepared to handle sample names that contain dashes ('-'). It would just split file names by the last dash and use that as sample name. E.g. if you have sample names like "A-very-long-sample-name-1", it would return only the last part: "1". By itself that may not be such a big problem, but when the Snakemake rule `quantify_output` tries to merge the counts with the classifications based on sample name and scaffold name, this will fail and you will end up with a Sample_composition_graph.html file with 0 for all taxa.

TLDR:
In short, this patch solves the problem of faulty composition graphs for datasets in which sample names have dashes in them.