### PR TITLE
Fix bug: NA values for NR_ORFs

### DIFF
--- a/bin/scripts/draw_heatmaps.py
+++ b/bin/scripts/draw_heatmaps.py
@@ -421,6 +421,8 @@ def draw_heatmaps(df, outfile, title, taxonomic_rank, colour):
                 
                 aggregated = False
                 
+                df.fillna(0, inplace=True)
+          
                 samples = df["Sample_name"].astype(str)
                 scaffolds = df["scaffold_name"].astype(str)
                 assigned = df["tax_name"].astype(str)


### PR DESCRIPTION
Draw heatmaps crashed on some samples, and it seemed that this was caused by 'non-finite' values being cast to integer values in `nr_orfs = df["Nr_ORFs"].astype(int)`.
This line of code is executed for taxa for which <=3 scaffolds are present. When more scaffolds are present, the heatmap will show 'aggregated statistics', and the dataframe for those statistics is filled with zeroes for NA values (see line 367: `new_df = new_df.fillna(0)`).
Therefore, I think a solution is to replace NA values in this piece of code as well.