### PR TITLE
Include nucl_gb.accession2taxid.gz for MGKit

### DIFF
--- a/bin/includes/Databases_installer
+++ b/bin/includes/Databases_installer
@@ -147,6 +147,9 @@ if [ "${PATHING_SINGLE}" == "TRUE" ]; then
             cd "${DB_PATH_MGKIT}" || exit
             printf "\nDownloading MGKit database... \n"
             bash "${CONDA_PREFIX}"/bin/download-taxonomy.sh ./
+            curl -o nucl_gb.accession2taxid.gz -L ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz
+            curl -o nucl_gb.accession2taxid.gz.md5 -L https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz.md5
+            md5sum -c nucl_gb.accession2taxid.gz.md5
 
             # ! download krona LCA db
             cd "${DB_PATH_KRONA}" || exit
@@ -194,6 +197,9 @@ perl "${CONDA_PREFIX}"/bin/update_blastdb.pl --decompress taxdb
 ### UPDATING MGKIT
 cd "${DB_PATH_MGKIT}" || exit 1
 bash "${CONDA_PREFIX}"/bin/download-taxonomy.sh ./
+curl -o nucl_gb.accession2taxid.gz -L ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz
+curl -o nucl_gb.accession2taxid.gz.md5 -L https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz.md5
+md5sum -c nucl_gb.accession2taxid.gz.md5
 
 ### UPDATING KRONA
 cd "${DB_PATH_KRONA}" || exit 1
@@ -316,6 +322,9 @@ if [ "${PATHING_DIFFERENT}" == "TRUE" ]; then
             cd "${DB_PATH_MGKIT}" || exit
             printf "\nDownloading MGKit LCA database... \n"
             bash "${CONDA_PREFIX}"/bin/download-taxonomy.sh ./
+            curl -o nucl_gb.accession2taxid.gz -L ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz
+            curl -o nucl_gb.accession2taxid.gz.md5 -L https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz.md5
+            md5sum -c nucl_gb.accession2taxid.gz.md5
                 
             # ! download krona LCA db
             cd "${DB_PATH_KRONA}" || exit
@@ -369,6 +378,9 @@ perl "${CONDA_PREFIX}"/bin/update_blastdb.pl --decompress taxdb
 ### UPDATING MGKIT
 cd "${DB_PATH_MGKIT}" || exit 1
 bash "${CONDA_PREFIX}"/bin/download-taxonomy.sh ./
+curl -o nucl_gb.accession2taxid.gz -L ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz
+curl -o nucl_gb.accession2taxid.gz.md5 -L https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz.md5
+md5sum -c nucl_gb.accession2taxid.gz.md5
 
 ### UPDATING KRONA
 cd "${DB_PATH_KRONA}" || exit 1


### PR DESCRIPTION
This file is necessary for the Snakemake rule 'addtaxa_gff' and is not included with the 'download-taxonomy.sh' script.