### PR TITLE
Fixed (mini)Conda installer for CentOS/RHEL 7 and Ubuntu

### DIFF
--- a/bin/includes/Install_jovian-master
+++ b/bin/includes/Install_jovian-master
@@ -4,6 +4,8 @@
 ### Install Jovian_master if it doesn't already exist, verify by activating master env in this nested shell.
 ### On succes, activate master env in real shell with an allexport
 
+source "${HOME}"/.bashrc
+
 if [[ $PATH != *${MASTER_NAME}* ]]; then 
 
 #? If the master environment is not in your path (i.e. it is not currently active), do...

--- a/bin/includes/Install_jovian-master
+++ b/bin/includes/Install_jovian-master
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/bash -i
 # shellcheck disable=SC1091
 
 ### Install Jovian_master if it doesn't already exist, verify by activating master env in this nested shell.
 ### On succes, activate master env in real shell with an allexport
 
-source "${HOME}"/.bashrc
+
 
 if [[ $PATH != *${MASTER_NAME}* ]]; then 
 

--- a/bin/includes/Install_jovian-master
+++ b/bin/includes/Install_jovian-master
@@ -19,7 +19,7 @@ if [[ $PATH != *${MASTER_NAME}* ]]; then
     
     #? Attempt to activate master conda env, if exit statement is not 0, i.e. master conda env hasn't been installed yet, do...
     
-
+        installer_intro
     
         if [ "${SKIP_CONFIRMATION}" = "TRUE" ]; then
     

--- a/bin/includes/Install_jovian-master
+++ b/bin/includes/Install_jovian-master
@@ -1,4 +1,4 @@
-#!/bin/bash -i
+#!/usr/bin/env bash
 # shellcheck disable=SC1091
 
 ### Install Jovian_master if it doesn't already exist, verify by activating master env in this nested shell.

--- a/bin/includes/Install_jovian-master
+++ b/bin/includes/Install_jovian-master
@@ -17,7 +17,7 @@ if [[ $PATH != *${MASTER_NAME}* ]]; then
     
     #? Attempt to activate master conda env, if exit statement is not 0, i.e. master conda env hasn't been installed yet, do...
     
-        installer_intro
+
     
         if [ "${SKIP_CONFIRMATION}" = "TRUE" ]; then
     

--- a/bin/includes/Install_jovian-master
+++ b/bin/includes/Install_jovian-master
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # shellcheck disable=SC1091
 
 ### Install Jovian_master if it doesn't already exist, verify by activating master env in this nested shell.

--- a/bin/includes/Install_miniconda
+++ b/bin/includes/Install_miniconda
@@ -40,11 +40,9 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
                 fi
             done
         fi
-        ### conda has been installed by previous step, confirm addition to PATH
-        echo -e "Conda is installed but not yet added to PATH, do you wish to add conda to your PATH?"
-        if [ "${SKIP_CONFIRMATION}" == "TRUE" ]; then
-            touch "${HOME}"/.jovianrc
-            cat << EOF >> "${HOME}"/.jovianrc
+
+    touch "${HOME}"/.jovianrc
+    cat << EOF >> "${HOME}"/.jovianrc
 __conda_setup="$('${HOME}/tmp/Miniconda3/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
 if [ $? -eq 0 ]; then
     eval "$__conda_setup"
@@ -64,57 +62,6 @@ export -f __conda_hashr
 export -f __add_sys_prefix_to_path
 
 EOF
-            source "${HOME}"/.jovianrc
-            line
-
-            echo -e "Conda succesfully added to PATH"
-        else
-            while read -r -p "The conda PATH will be added to your ~/.bashrc and will only affect you. [y/N] " answer
-            do
-                answer=${answer,,}
-                if [[ "${answer}" =~ ^(yes|y)$ ]]; then
-                    touch "${HOME}"/.jovianrc
-                    cat << EOF >> "${HOME}"/.jovianrc
-__conda_setup="$('${HOME}/tmp/Miniconda3/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
-if [ $? -eq 0 ]; then
-    eval "$__conda_setup"
-else
-    if [ -f "${HOME}/tmp/Miniconda3/etc/profile.d/conda.sh" ]; then
-        . "${HOME}/tmp/Miniconda3/etc/profile.d/conda.sh"
-    else
-        export PATH="${HOME}/tmp/Miniconda3/bin:$PATH"
-    fi
-fi
-unset __conda_setup
-
-export -f conda
-export -f __conda_activate
-export -f __conda_reactivate
-export -f __conda_hashr
-export -f __add_sys_prefix_to_path
-
-EOF
-
-                    source "${HOME}"/.jovianrc
-                    line
-
-                    echo -e "Conda succesfully added to PATH"
-                    break
-                elif [[ "${answer}" =~ ^(no|n)$ ]]; then
-                    export PATH=${HOME}/tmp/Miniconda3/bin:$PATH | tee -a ${INSTALL_LOG}
-
-                    line
-
-                    line
-                    spacer
-                    echo -e "Conda has not been permanently added to PATH, this means you cannot use the conda command once this session closes."
-                    break
-                else
-                    echo -e "Please answer with 'yes' or 'no'"
-                    minispacer
-                fi
-            done
-        fi
     
         echo -e "\n"
         echo -e "Installation of Conda is done"

--- a/bin/includes/Install_miniconda
+++ b/bin/includes/Install_miniconda
@@ -1,4 +1,4 @@
-#!/bin/bash -i
+#!/usr/bin/env bash
 # shellcheck disable=SC1091
 
 if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. the `conda` command is not available), if true, install it in ~/tmp. Otherwise, proceed.

--- a/bin/includes/Install_miniconda
+++ b/bin/includes/Install_miniconda
@@ -94,6 +94,8 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
         echo -e "If you wish to use conda then it might be necessary to restart your terminal session"
         source "${HOME}"/.bashrc
 
+        conda config --set channel_priority false
+        
         echo -e "\n\nContinuing..."
         sleep 5
 

--- a/bin/includes/Install_miniconda
+++ b/bin/includes/Install_miniconda
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # shellcheck disable=SC1091
 
 if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. the `conda` command is not available), if true, install it in ~/tmp. Otherwise, proceed.

--- a/bin/includes/Install_miniconda
+++ b/bin/includes/Install_miniconda
@@ -43,15 +43,28 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
         ### conda has been installed by previous step, confirm addition to PATH
         echo -e "Conda is installed but not yet added to PATH, do you wish to add conda to your PATH?"
         if [ "${SKIP_CONFIRMATION}" == "TRUE" ]; then
-            export PATH=${HOME}/tmp/Miniconda3/bin:$PATH
-            conda init bash | tee -a ${INSTALL_LOG}
-            echo "export -f conda" >> "${HOME}"/.bashrc
-            echo "export -f __conda_activate" >> "${HOME}"/.bashrc
-            echo "export -f __conda_reactivate" >> "${HOME}"/.bashrc
-            echo "export -f __conda_hashr" >> "${HOME}"/.bashrc
-            echo "export -f __add_sys_prefix_to_path" >> "${HOME}"/.bashrc
-            source "${HOME}"/.bashrc | tee -a ${INSTALL_LOG}
+            touch "${HOME}"/.jovianrc
+            cat << EOF >> "${HOME}"/.jovianrc
+__conda_setup="$('${HOME}/tmp/Miniconda3/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "${HOME}/tmp/Miniconda3/etc/profile.d/conda.sh" ]; then
+        . "${HOME}/tmp/Miniconda3/etc/profile.d/conda.sh"
+    else
+        export PATH="${HOME}/tmp/Miniconda3/bin:$PATH"
+    fi
+fi
+unset __conda_setup
 
+export -f conda
+export -f __conda_activate
+export -f __conda_reactivate
+export -f __conda_hashr
+export -f __add_sys_prefix_to_path
+
+EOF
+            source "${HOME}"/.jovianrc
             line
 
             echo -e "Conda succesfully added to PATH"
@@ -60,15 +73,29 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
             do
                 answer=${answer,,}
                 if [[ "${answer}" =~ ^(yes|y)$ ]]; then
-                    export PATH=${HOME}/tmp/Miniconda3/bin:$PATH
-                    conda init bash | tee -a ${INSTALL_LOG}
-                    echo "export -f conda" >> "${HOME}"/.bashrc
-                    echo "export -f __conda_activate" >> "${HOME}"/.bashrc
-                    echo "export -f __conda_reactivate" >> "${HOME}"/.bashrc
-                    echo "export -f __conda_hashr" >> "${HOME}"/.bashrc
-                    echo "export -f __add_sys_prefix_to_path" >> "${HOME}"/.bashrc
-                    source "${HOME}"/.bashrc | tee -a ${INSTALL_LOG}
+                    touch "${HOME}"/.jovianrc
+                    cat << EOF >> "${HOME}"/.jovianrc
+__conda_setup="$('${HOME}/tmp/Miniconda3/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "${HOME}/tmp/Miniconda3/etc/profile.d/conda.sh" ]; then
+        . "${HOME}/tmp/Miniconda3/etc/profile.d/conda.sh"
+    else
+        export PATH="${HOME}/tmp/Miniconda3/bin:$PATH"
+    fi
+fi
+unset __conda_setup
 
+export -f conda
+export -f __conda_activate
+export -f __conda_reactivate
+export -f __conda_hashr
+export -f __add_sys_prefix_to_path
+
+EOF
+
+                    source "${HOME}"/.jovianrc
                     line
 
                     echo -e "Conda succesfully added to PATH"
@@ -92,7 +119,7 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
         echo -e "\n"
         echo -e "Installation of Conda is done"
         echo -e "If you wish to use conda then it might be necessary to restart your terminal session"
-        source "${HOME}"/.bashrc
+        source "${HOME}"/.jovianrc
 
         conda config --set channel_priority false
 

--- a/bin/includes/Install_miniconda
+++ b/bin/includes/Install_miniconda
@@ -4,7 +4,7 @@
 if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. the `conda` command is not available), if true, install it in ~/tmp. Otherwise, proceed.
     if [ ! -e "${HOME}/tmp/Miniconda3" ]; then
         ### confirmation of conda installation
-        installer_intro
+
         echo -e "Miniconda missing. Installing Miniconda can take up to 15 minutes..."
         if [ "${SKIP_CONFIRMATION}" == "TRUE" ]; then
             echo "Jovian ${VERSION}" > ${INSTALL_LOG}
@@ -13,8 +13,8 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
             chmod +x latest.sh
             sh latest.sh -b -p "${HOME}/tmp/Miniconda3" | tee -a ${INSTALL_LOG}
             rm latest.sh
-            tput reset
-            installer_intro
+
+
         else
             while read -r -p "Do you wish to install (mini)conda now? [y/N] " response
             do
@@ -31,8 +31,8 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
                     chmod +x latest.sh
                     sh latest.sh -b -p "${HOME}/tmp/Miniconda3" | tee -a ${INSTALL_LOG}
                     rm latest.sh
-                    tput reset
-                    installer_intro
+
+
                     break
                 else
                     echo -e "Please answer with 'yes' or 'no'"
@@ -51,9 +51,9 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
             echo "export -f __conda_hashr" >> "${HOME}"/.bashrc
             echo "export -f __add_sys_prefix_to_path" >> "${HOME}"/.bashrc
             source "${HOME}"/.bashrc | tee -a ${INSTALL_LOG}
-            tput reset
+
             line
-            installer_intro
+
             echo -e "Conda succesfully added to PATH"
         else
             while read -r -p "The conda PATH will be added to your ~/.bashrc and will only affect you. [y/N] " answer
@@ -68,16 +68,16 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
                     echo "export -f __conda_hashr" >> "${HOME}"/.bashrc
                     echo "export -f __add_sys_prefix_to_path" >> "${HOME}"/.bashrc
                     source "${HOME}"/.bashrc | tee -a ${INSTALL_LOG}
-                    tput reset
+
                     line
-                    installer_intro
+
                     echo -e "Conda succesfully added to PATH"
                     break
                 elif [[ "${answer}" =~ ^(no|n)$ ]]; then
                     export PATH=${HOME}/tmp/Miniconda3/bin:$PATH | tee -a ${INSTALL_LOG}
-                    tput reset
+
                     line
-                    installer_intro
+
                     line
                     spacer
                     echo -e "Conda has not been permanently added to PATH, this means you cannot use the conda command once this session closes."
@@ -95,11 +95,11 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
         source "${HOME}"/.bashrc
 
         conda config --set channel_priority false
-        
+
         echo -e "\n\nContinuing..."
         sleep 5
 
-        installer_intro
+
         line
         spacer
     fi

--- a/bin/includes/Install_miniconda
+++ b/bin/includes/Install_miniconda
@@ -43,9 +43,14 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
         ### conda has been installed by previous step, confirm addition to PATH
         echo -e "Conda is installed but not yet added to PATH, do you wish to add conda to your PATH?"
         if [ "${SKIP_CONFIRMATION}" == "TRUE" ]; then
-            echo "PATH=$PATH:${HOME}/tmp/Miniconda3/bin" >> "${HOME}/.bashrc" | tee -a ${INSTALL_LOG}
-            source "${HOME}"/.bashrc | tee -a ${INSTALL_LOG}
             export PATH=${HOME}/tmp/Miniconda3/bin:$PATH
+            conda init bash | tee -a ${INSTALL_LOG}
+            echo "export -f conda" >> "${HOME}"/.bashrc
+            echo "export -f __conda_activate" >> "${HOME}"/.bashrc
+            echo "export -f __conda_reactivate" >> "${HOME}"/.bashrc
+            echo "export -f __conda_hashr" >> "${HOME}"/.bashrc
+            echo "export -f __add_sys_prefix_to_path" >> "${HOME}"/.bashrc
+            source "${HOME}"/.bashrc | tee -a ${INSTALL_LOG}
             tput reset
             line
             installer_intro
@@ -55,9 +60,14 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
             do
                 answer=${answer,,}
                 if [[ "${answer}" =~ ^(yes|y)$ ]]; then
-                    echo "PATH=$PATH:${HOME}/tmp/Miniconda3/bin" >> "${HOME}/.bashrc" | tee -a ${INSTALL_LOG}
-                    source "${HOME}"/.bashrc | tee -a ${INSTALL_LOG}
                     export PATH=${HOME}/tmp/Miniconda3/bin:$PATH
+                    conda init bash | tee -a ${INSTALL_LOG}
+                    echo "export -f conda" >> "${HOME}"/.bashrc
+                    echo "export -f __conda_activate" >> "${HOME}"/.bashrc
+                    echo "export -f __conda_reactivate" >> "${HOME}"/.bashrc
+                    echo "export -f __conda_hashr" >> "${HOME}"/.bashrc
+                    echo "export -f __add_sys_prefix_to_path" >> "${HOME}"/.bashrc
+                    source "${HOME}"/.bashrc | tee -a ${INSTALL_LOG}
                     tput reset
                     line
                     installer_intro

--- a/bin/includes/Install_miniconda
+++ b/bin/includes/Install_miniconda
@@ -4,7 +4,7 @@
 if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. the `conda` command is not available), if true, install it in ~/tmp. Otherwise, proceed.
     if [ ! -e "${HOME}/tmp/Miniconda3" ]; then
         ### confirmation of conda installation
-
+        installer_intro
         echo -e "Miniconda missing. Installing Miniconda can take up to 15 minutes..."
         if [ "${SKIP_CONFIRMATION}" == "TRUE" ]; then
             echo "Jovian ${VERSION}" > ${INSTALL_LOG}
@@ -13,8 +13,8 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
             chmod +x latest.sh
             sh latest.sh -b -p "${HOME}/tmp/Miniconda3" | tee -a ${INSTALL_LOG}
             rm latest.sh
-
-
+            tput reset
+            installer_intro
         else
             while read -r -p "Do you wish to install (mini)conda now? [y/N] " response
             do
@@ -31,8 +31,8 @@ if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. 
                     chmod +x latest.sh
                     sh latest.sh -b -p "${HOME}/tmp/Miniconda3" | tee -a ${INSTALL_LOG}
                     rm latest.sh
-
-
+                    tput reset
+                    installer_intro
                     break
                 else
                     echo -e "Please answer with 'yes' or 'no'"
@@ -73,7 +73,7 @@ EOF
         echo -e "\n\nContinuing..."
         sleep 5
 
-
+        installer_intro
         line
         spacer
     fi

--- a/bin/includes/Install_miniconda
+++ b/bin/includes/Install_miniconda
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -i
 # shellcheck disable=SC1091
 
 if ! command -v conda > /dev/null; then # Check if conda is not installed (i.e. the `conda` command is not available), if true, install it in ~/tmp. Otherwise, proceed.

--- a/jovian
+++ b/jovian
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -i
 ############################################################################################################
 ### Authors:                                                                                             ###
 ###     Dennis Schmitz, Sam Nooij, Florian Zwagemaker, Robert Verhagen,                                  ###

--- a/jovian
+++ b/jovian
@@ -227,11 +227,11 @@ fi
 ###> Runs if the command "conda" is not recognised by the host AND if the "~/tmp/miniconda3" path is non-existant
 if ! bash bin/includes/Install_miniconda; then
     exit 1
+else
+    set -o allexport
+    source "${HOME}"/.jovianrc
+    set +o allexport
 fi
-
-set -o allexport
-source "${HOME}"/.bashrc
-set +o allexport
 
 ###> Installer for Jovian_master environment.
 ###> Runs if the master environment is not active (in path) and is not installed either. Activates environment on finish

--- a/jovian
+++ b/jovian
@@ -227,7 +227,9 @@ fi
 ###> Runs if the command "conda" is not recognised by the host AND if the "~/tmp/miniconda3" path is non-existant
 if ! bash bin/includes/Install_miniconda; then
     exit 1
-else
+fi
+
+if [ ! -e "${HOME}/tmp/Miniconda3" ]; then
     set -o allexport
     source "${HOME}"/.jovianrc
     set +o allexport

--- a/jovian
+++ b/jovian
@@ -229,7 +229,7 @@ if ! bash bin/includes/Install_miniconda; then
     exit 1
 fi
 
-if [ ! -e "${HOME}/tmp/Miniconda3" ]; then
+if [ -e "${HOME}/tmp/Miniconda3" ]; then
     set -o allexport
     source "${HOME}"/.jovianrc
     set +o allexport

--- a/jovian
+++ b/jovian
@@ -1,4 +1,4 @@
-#!/bin/bash -i
+#!/usr/bin/env bash
 ############################################################################################################
 ### Authors:                                                                                             ###
 ###     Dennis Schmitz, Sam Nooij, Florian Zwagemaker, Robert Verhagen,                                  ###

--- a/jovian
+++ b/jovian
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 ############################################################################################################
 ### Authors:                                                                                             ###
 ###     Dennis Schmitz, Sam Nooij, Florian Zwagemaker, Robert Verhagen,                                  ###

--- a/jovian
+++ b/jovian
@@ -227,11 +227,11 @@ fi
 ###> Runs if the command "conda" is not recognised by the host AND if the "~/tmp/miniconda3" path is non-existant
 if ! bash bin/includes/Install_miniconda; then
     exit 1
-else
-    set -o allexport
-    source "${HOME}"/.bashrc
-    set +o allexport
 fi
+
+set -o allexport
+source "${HOME}"/.bashrc
+set +o allexport
 
 ###> Installer for Jovian_master environment.
 ###> Runs if the master environment is not active (in path) and is not installed either. Activates environment on finish


### PR DESCRIPTION
Ditched the use of `~/.bashrc` for `~/.jovianrc`

This is done because the `.bashrc` file on Ubuntu systems has the following codeblock at the top:
```
case $- in
    *i*) ;;
    *) return ;;
esac
```
This means that "sourcing"  the `.bashrc` file on Ubuntu systems is not possible when done from a script.

I decided to use a new file `~/.jovianrc` in order to get around this problem, and therefore allowing is to properly install miniConda.

We might have to look for a different approach in the future as this isn't a particularly neat way of solving the issue. But hey it works

Error catching etc still have to be added