### PR TITLE
Accept pd.concat new behaviour

### DIFF
--- a/bin/scripts/quantify_profiles.py
+++ b/bin/scripts/quantify_profiles.py
@@ -339,7 +339,7 @@ def sum_superkingdoms(classified_file, mapped_reads_file):
                 pass
     
     #Concatenate the missing data into the dataframe
-    new_df = pd.concat([superkingdom_sums, newdata])
+    new_df = pd.concat([superkingdom_sums, newdata], sort = False)
     new_df.reset_index(inplace=True)
     new_df = new_df.sort_values(by=['Sample_name', 'superkingdom'])
     new_df = new_df.dropna()


### PR DESCRIPTION
The function pd.concat has been changed, causing the warning below. This commit accepts the new behaviour, so no warnings are given anymore.

  bin/quantify_profiles.py:342: FutureWarning: Sorting because non-concatenation axis is not aligned. A future version
of pandas will change to not sort by default.

  To accept the future behavior, pass 'sort=False'.

  To retain the current behavior and silence the warning, pass 'sort=True'.

    new_df = pd.concat([superkingdom_sums, newdata])