### PR TITLE
Request memory resources

### DIFF
--- a/bin/includes/Userconfig_CM
+++ b/bin/includes/Userconfig_CM
@@ -57,7 +57,7 @@ if [ "$cm_installeranswers_compmode" == "U" ]; then
                 echo -e "installeranswers:\n    compmode: G\n   queue: ${queueanswer}" > "${HOME}"/.jovian_installchoice_compmode
                 sed -i '\|drmaa|d' config/config.yaml
                 sed -i "s/.*local-cores:.*/${gridmode_localcores}/g" config/config.yaml
-                echo -e "drmaa: \" -q ${queueanswer} -n {threads} -R \\\"span[hosts=1]\\\"\"" >> config/config.yaml
+                echo -e "drmaa: \" -q ${queueanswer} -n {threads} -R \\\"span[hosts=1]\\\" -R \\\"rusage[mem={resources.memory}GB]\\\"\"" >> config/config.yaml
                 echo -e "drmaa-log-dir: logs/drmaa" >> config/config.yaml
                 break
             done
@@ -101,6 +101,6 @@ elif [ "${cm_installeranswers_compmode}" == "G" ]; then
     echo -e "Jovian is set to run in computing mode: Grid.\n"
     sed -i '\|drmaa|d' config/config.yaml
     sed -i "s/.*local-cores:.*/${gridmode_localcores}/g" config/config.yaml
-    echo -e "drmaa: \" -q ${cm_installeranswers_queue} -n {threads} -R \\\"span[hosts=1]\\\"\"" >> config/config.yaml
+    echo -e "drmaa: \" -q ${cm_installeranswers_queue} -n {threads} -R \\\"span[hosts=1]\\\" -R \\\"rusage[mem={resources.memory}GB]\\\"\"" >> config/config.yaml
     echo -e "drmaa-log-dir: logs/drmaa" >> config/config.yaml
 fi

--- a/bin/includes/Userconfig_CM
+++ b/bin/includes/Userconfig_CM
@@ -57,7 +57,7 @@ if [ "$cm_installeranswers_compmode" == "U" ]; then
                 echo -e "installeranswers:\n    compmode: G\n   queue: ${queueanswer}" > "${HOME}"/.jovian_installchoice_compmode
                 sed -i '\|drmaa|d' config/config.yaml
                 sed -i "s/.*local-cores:.*/${gridmode_localcores}/g" config/config.yaml
-                echo -e "drmaa: \" -q ${queueanswer} -n {threads} -R \\\"span[hosts=1]\\\" -R \\\"rusage[mem={resources.memory}GB]\\\"\"" >> config/config.yaml
+                echo -e "drmaa: \" -q ${queueanswer} -n {threads} -R 'span[hosts=1]' -R 'rusage[mem={resources.memory}]'\"" >> config/config.yaml
                 echo -e "drmaa-log-dir: logs/drmaa" >> config/config.yaml
                 break
             done
@@ -101,6 +101,6 @@ elif [ "${cm_installeranswers_compmode}" == "G" ]; then
     echo -e "Jovian is set to run in computing mode: Grid.\n"
     sed -i '\|drmaa|d' config/config.yaml
     sed -i "s/.*local-cores:.*/${gridmode_localcores}/g" config/config.yaml
-    echo -e "drmaa: \" -q ${cm_installeranswers_queue} -n {threads} -R \\\"span[hosts=1]\\\" -R \\\"rusage[mem={resources.memory}GB]\\\"\"" >> config/config.yaml
+    echo -e "drmaa: \" -q ${cm_installeranswers_queue} -n {threads} -R 'span[hosts=1]' -R 'rusage[mem={resources.memory}]'\"" >> config/config.yaml
     echo -e "drmaa-log-dir: logs/drmaa" >> config/config.yaml
 fi

--- a/bin/rules/BG_removal_1.smk
+++ b/bin/rules/BG_removal_1.smk
@@ -22,7 +22,7 @@ rule HuGo_removal_pt1_alignment:
         f"{logdir + bench}" + "HuGo_removal_pt1_alignment_{sample}.txt"
     threads: config["threads"]["HuGo_removal"]
     resources: 
-        memory = config["threads"]["HuGo_removal"] * 12
+        memory = (config["threads"]["HuGo_removal"] * 12) * 1024
     params:
         alignment_type  =   config["Global"]["HuGo_removal_method"]
     shell:

--- a/bin/rules/BG_removal_1.smk
+++ b/bin/rules/BG_removal_1.smk
@@ -21,6 +21,8 @@ rule HuGo_removal_pt1_alignment:
     benchmark:
         f"{logdir + bench}" + "HuGo_removal_pt1_alignment_{sample}.txt"
     threads: config["threads"]["HuGo_removal"]
+    resources: 
+        memory = config["threads"]["HuGo_removal"] * 12
     params:
         alignment_type  =   config["Global"]["HuGo_removal_method"]
     shell:

--- a/bin/rules/BG_removal_2.smk
+++ b/bin/rules/BG_removal_2.smk
@@ -19,7 +19,7 @@ rule HuGo_removal_pt2_extract_paired_unmapped_reads:
         f"{logdir + bench}" + "HuGo_removal_pt2_extract_paired_unmapped_reads_{sample}.txt"
     threads: config["threads"]["HuGo_removal"]
     resources: 
-        memory = config["threads"]["HuGo_removal"] * 12
+        memory = (config["threads"]["HuGo_removal"] * 12) * 1024
     shell:
         """
 samtools view -@ {threads} -b -f 1 -f 4 -f 8 {input.bam} 2> {log} |\

--- a/bin/rules/BG_removal_2.smk
+++ b/bin/rules/BG_removal_2.smk
@@ -6,11 +6,11 @@
 
 rule HuGo_removal_pt2_extract_paired_unmapped_reads:
     input:
-         bam        =   rules.HuGo_removal_pt1_alignment.output.sorted_bam,
-         bam_index  =   rules.HuGo_removal_pt1_alignment.output.sorted_bam_index
+        bam        =   rules.HuGo_removal_pt1_alignment.output.sorted_bam,
+        bam_index  =   rules.HuGo_removal_pt1_alignment.output.sorted_bam_index
     output:
-         fastq_R1   =   f"{datadir + cln}" + "{sample}_pR1.fq",
-         fastq_R2   =   f"{datadir + cln}" + "{sample}_pR2.fq"
+        fastq_R1   =   f"{datadir + cln}" + "{sample}_pR1.fq",
+        fastq_R2   =   f"{datadir + cln}" + "{sample}_pR2.fq"
     conda:
         f"{conda_envs}HuGo_removal.yaml"
     log:
@@ -18,6 +18,8 @@ rule HuGo_removal_pt2_extract_paired_unmapped_reads:
     benchmark:
         f"{logdir + bench}" + "HuGo_removal_pt2_extract_paired_unmapped_reads_{sample}.txt"
     threads: config["threads"]["HuGo_removal"]
+    resources: 
+        memory = config["threads"]["HuGo_removal"] * 12
     shell:
         """
 samtools view -@ {threads} -b -f 1 -f 4 -f 8 {input.bam} 2> {log} |\

--- a/bin/rules/BG_removal_3.smk
+++ b/bin/rules/BG_removal_3.smk
@@ -17,6 +17,8 @@ rule HuGo_removal_pt3_extract_unpaired_unmapped_reads:
     benchmark:
         f"{logdir + bench}" + "HuGo_removal_pt3_extract_unpaired_unmapped_reads_{sample}.txt"
     threads: config["threads"]["HuGo_removal"]
+    resources: 
+        memory = config["threads"]["HuGo_removal"] * 12
     shell:
         """
 samtools view -@ {threads} -b -F 1 -f 4 {input.bam} 2> {log} |\

--- a/bin/rules/BG_removal_3.smk
+++ b/bin/rules/BG_removal_3.smk
@@ -18,7 +18,7 @@ rule HuGo_removal_pt3_extract_unpaired_unmapped_reads:
         f"{logdir + bench}" + "HuGo_removal_pt3_extract_unpaired_unmapped_reads_{sample}.txt"
     threads: config["threads"]["HuGo_removal"]
     resources: 
-        memory = config["threads"]["HuGo_removal"] * 12
+        memory = (config["threads"]["HuGo_removal"] * 12) * 1024
     shell:
         """
 samtools view -@ {threads} -b -F 1 -f 4 {input.bam} 2> {log} |\

--- a/bin/rules/Blast.smk
+++ b/bin/rules/Blast.smk
@@ -16,6 +16,8 @@ rule Scaffold_classification:
     benchmark:
         f"{logdir + bench}" + "logs/benchmark/Scaffold_classification_{sample}.txt"
     threads: config["threads"]["Classification_of_scaffolds"]
+    resources: 
+        memory = config["threads"]["Classification_of_scaffolds"] * 12
     params:
         outfmt          =   "6 std qseqid sseqid staxids sscinames stitle",
         evalue          =   config["Illumina_meta"]["Classification"]["e_value"],

--- a/bin/rules/Blast.smk
+++ b/bin/rules/Blast.smk
@@ -17,7 +17,7 @@ rule Scaffold_classification:
         f"{logdir + bench}" + "logs/benchmark/Scaffold_classification_{sample}.txt"
     threads: config["threads"]["Classification_of_scaffolds"]
     resources: 
-        memory = config["threads"]["Classification_of_scaffolds"] * 12
+        memory = (config["threads"]["Classification_of_scaffolds"] * 12) * 1024
     params:
         outfmt          =   "6 std qseqid sseqid staxids sscinames stitle",
         evalue          =   config["Illumina_meta"]["Classification"]["e_value"],

--- a/bin/rules/CleanData.smk
+++ b/bin/rules/CleanData.smk
@@ -22,7 +22,7 @@ rule Clean_the_data:
         f"{logdir + bench}" + "Clean_the_data_{sample}.txt"
     threads: config["threads"]["Clean_the_data"]
     resources:
-        memory = config["threads"]["Clean_the_data"] * 4
+        memory = (config["threads"]["Clean_the_data"] * 4) * 1024
     params:
         adapter_removal_config  =   config["Illumina"]["Clean"]["adapter_removal_config"],
         quality_trimming_config =   config["Illumina"]["Clean"]["quality_trimming_config"],

--- a/bin/rules/CleanData.smk
+++ b/bin/rules/CleanData.smk
@@ -21,6 +21,8 @@ rule Clean_the_data:
     benchmark:
         f"{logdir + bench}" + "Clean_the_data_{sample}.txt"
     threads: config["threads"]["Clean_the_data"]
+    resources:
+        memory = config["threads"]["Clean_the_data"] * 4
     params:
         adapter_removal_config  =   config["Illumina"]["Clean"]["adapter_removal_config"],
         quality_trimming_config =   config["Illumina"]["Clean"]["quality_trimming_config"],

--- a/bin/rules/Concat_SNPs.smk
+++ b/bin/rules/Concat_SNPs.smk
@@ -19,7 +19,7 @@ rule Concat_filtered_SNPs:
         f"{logdir + bench}Concat_filtered_SNPs.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     params:
         vcf_folder_glob =   f"{datadir + scf_filt}/\*_filtered.vcf"
     shell:

--- a/bin/rules/Concat_SNPs.smk
+++ b/bin/rules/Concat_SNPs.smk
@@ -18,6 +18,8 @@ rule Concat_filtered_SNPs:
     benchmark:
         f"{logdir + bench}Concat_filtered_SNPs.txt"
     threads: 1
+    resources:
+        memory = 4
     params:
         vcf_folder_glob =   f"{datadir + scf_filt}/\*_filtered.vcf"
     shell:

--- a/bin/rules/Concat_files.smk
+++ b/bin/rules/Concat_files.smk
@@ -22,6 +22,8 @@ rule Concat_files:
     benchmark:
         f"{logdir + bench}Concat_files.txt"
     threads: 1
+    resources:
+        memory = 4
     params:
         search_folder       =   f"{datadir + tbl}",
         classified_glob     =   "*_taxClassified.tsv",

--- a/bin/rules/Concat_files.smk
+++ b/bin/rules/Concat_files.smk
@@ -23,7 +23,7 @@ rule Concat_files:
         f"{logdir + bench}Concat_files.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     params:
         search_folder       =   f"{datadir + tbl}",
         classified_glob     =   "*_taxClassified.tsv",

--- a/bin/rules/Concat_reads.smk
+++ b/bin/rules/Concat_reads.smk
@@ -18,6 +18,8 @@ rule concatenate_read_counts:
     benchmark:
         f"{logdir + bench}concatenate_read_counts.txt"
     threads: 1
+    resources:
+        memory = 4
     shell:
         """
         bin/scripts/concatenate_mapped_read_counts.py \

--- a/bin/rules/Concat_reads.smk
+++ b/bin/rules/Concat_reads.smk
@@ -19,7 +19,7 @@ rule concatenate_read_counts:
         f"{logdir + bench}concatenate_read_counts.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     shell:
         """
         bin/scripts/concatenate_mapped_read_counts.py \

--- a/bin/rules/Contig_metrics.smk
+++ b/bin/rules/Contig_metrics.smk
@@ -21,7 +21,7 @@ rule Generate_contigs_metrics:
         f"{logdir + bench}" + "Generate_contigs_metrics_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     shell: #! bbtools' pileup.sh counts every read, even those marked as duplicate upstream. Hence, upstream all duplicates are HARD removed.
         """
 pileup.sh in={input.bam} \

--- a/bin/rules/Contig_metrics.smk
+++ b/bin/rules/Contig_metrics.smk
@@ -20,6 +20,8 @@ rule Generate_contigs_metrics:
     benchmark:
         f"{logdir + bench}" + "Generate_contigs_metrics_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     shell: #! bbtools' pileup.sh counts every read, even those marked as duplicate upstream. Hence, upstream all duplicates are HARD removed.
         """
 pileup.sh in={input.bam} \

--- a/bin/rules/Count_reads.smk
+++ b/bin/rules/Count_reads.smk
@@ -16,6 +16,8 @@ rule count_mapped_reads:
     benchmark:
         f"{logdir + bench}" + "count_mapped_reads-{sample}.txt"
     threads: 1
+    resources:
+        memory = 12
     shell:
         """
 bash bin/scripts/count_mapped_reads.sh {input} > {output} 2> {log}

--- a/bin/rules/Count_reads.smk
+++ b/bin/rules/Count_reads.smk
@@ -17,7 +17,7 @@ rule count_mapped_reads:
         f"{logdir + bench}" + "count_mapped_reads-{sample}.txt"
     threads: 1
     resources:
-        memory = 12
+        memory = 12 * 1024
     shell:
         """
 bash bin/scripts/count_mapped_reads.sh {input} > {output} 2> {log}

--- a/bin/rules/GC_content.smk
+++ b/bin/rules/GC_content.smk
@@ -20,7 +20,7 @@ rule Determine_GC_content:
         f"{logdir + bench}" + "Determine_GC_content_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     params:
         window_size =   config["Global"]["GC_window_size"]
     shell:

--- a/bin/rules/GC_content.smk
+++ b/bin/rules/GC_content.smk
@@ -19,6 +19,8 @@ rule Determine_GC_content:
     benchmark:
         f"{logdir + bench}" + "Determine_GC_content_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     params:
         window_size =   config["Global"]["GC_window_size"]
     shell:

--- a/bin/rules/Heatmaps.smk
+++ b/bin/rules/Heatmaps.smk
@@ -25,6 +25,8 @@ rule draw_heatmaps:
     benchmark:
         f"{logdir + bench}draw_heatmaps.txt"
     threads: 1
+    resources:
+        memory = 12
     shell:
         """
 python bin/scripts/draw_heatmaps.py -c {input.classified} -n {input.numbers} -sq {output.super_quantities} -st {output.stats} -vs {output.vir_stats} -ps {output.phage_stats} -bs {output.bact_stats} -s {output.super} -v {output.virus} -p {output.phage} -b {output.bact} > {log} 2>&1

--- a/bin/rules/Heatmaps.smk
+++ b/bin/rules/Heatmaps.smk
@@ -26,7 +26,7 @@ rule draw_heatmaps:
         f"{logdir + bench}draw_heatmaps.txt"
     threads: 1
     resources:
-        memory = 12
+        memory = 12 * 1024
     shell:
         """
 python bin/scripts/draw_heatmaps.py -c {input.classified} -n {input.numbers} -sq {output.super_quantities} -st {output.stats} -vs {output.vir_stats} -ps {output.phage_stats} -bs {output.bact_stats} -s {output.super} -v {output.virus} -p {output.phage} -b {output.bact} > {log} 2>&1

--- a/bin/rules/IGVjs.smk
+++ b/bin/rules/IGVjs.smk
@@ -24,7 +24,7 @@ rule HTML_IGVJs_variable_parts:
         f"{logdir + bench}" + "HTML_IGVJs_variable_parts_{sample}.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     shell:
         """
 bash bin/html/igvjs_write_tabs.sh {wildcards.sample} {output.tab_output}
@@ -57,7 +57,7 @@ rule HTML_IGVJs_generate_final:
         f"{logdir + bench}benchmark/HTML_IGVJs_generate_final.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     params:
         tab_basename    =   f"{datadir + html}2_tab_",
         div_basename    =   f"{datadir + html}4_html_divs_",

--- a/bin/rules/IGVjs.smk
+++ b/bin/rules/IGVjs.smk
@@ -23,6 +23,8 @@ rule HTML_IGVJs_variable_parts:
     benchmark:
         f"{logdir + bench}" + "HTML_IGVJs_variable_parts_{sample}.txt"
     threads: 1
+    resources:
+        memory = 4
     shell:
         """
 bash bin/html/igvjs_write_tabs.sh {wildcards.sample} {output.tab_output}
@@ -54,6 +56,8 @@ rule HTML_IGVJs_generate_final:
     benchmark:
         f"{logdir + bench}benchmark/HTML_IGVJs_generate_final.txt"
     threads: 1
+    resources:
+        memory = 4
     params:
         tab_basename    =   f"{datadir + html}2_tab_",
         div_basename    =   f"{datadir + html}4_html_divs_",

--- a/bin/rules/ILM_Ref_GC_content.smk
+++ b/bin/rules/ILM_Ref_GC_content.smk
@@ -13,6 +13,8 @@ rule Illumina_determine_GC_content:
     benchmark:
         f"{logdir + bench}" + "Illumina_determine_GC_content_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     params:
         window_size =   config["Global"]["GC_window_size"]
     shell:

--- a/bin/rules/ILM_Ref_GC_content.smk
+++ b/bin/rules/ILM_Ref_GC_content.smk
@@ -14,7 +14,7 @@ rule Illumina_determine_GC_content:
         f"{logdir + bench}" + "Illumina_determine_GC_content_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     params:
         window_size =   config["Global"]["GC_window_size"]
     shell:

--- a/bin/rules/ILM_Ref_ORF_analysis.smk
+++ b/bin/rules/ILM_Ref_ORF_analysis.smk
@@ -15,7 +15,7 @@ rule Illumina_reference_ORF_analysis:
         f"{logdir + bench}" + "Illumina_reference_ORF_analysis_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     params: #? Currently it's using the same prodigal settings as the main workflow, I see no problems with it since it's both foremost intended for viruses.
         procedure       =   config["Global"]["ORF_procedure"],
         output_format   =   config["Global"]["ORF_output_format"]

--- a/bin/rules/ILM_Ref_ORF_analysis.smk
+++ b/bin/rules/ILM_Ref_ORF_analysis.smk
@@ -14,6 +14,8 @@ rule Illumina_reference_ORF_analysis:
     benchmark:
         f"{logdir + bench}" + "Illumina_reference_ORF_analysis_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     params: #? Currently it's using the same prodigal settings as the main workflow, I see no problems with it since it's both foremost intended for viruses.
         procedure       =   config["Global"]["ORF_procedure"],
         output_format   =   config["Global"]["ORF_output_format"]

--- a/bin/rules/ILM_Ref_QC_clean.smk
+++ b/bin/rules/ILM_Ref_QC_clean.smk
@@ -11,7 +11,7 @@ rule ILM_Ref_QC_clean_data:
         f"{logdir + bench}" + "QC_clean_data_{sample}.txt"
     threads: 6
     resources:
-        memory = 12
+        memory = 12 * 1024
     shell:
         """
 if [ -s "{input}" ] # If file exists and is NOT empty (i.e. filesize > 0) do...

--- a/bin/rules/ILM_Ref_QC_clean.smk
+++ b/bin/rules/ILM_Ref_QC_clean.smk
@@ -10,6 +10,8 @@ rule ILM_Ref_QC_clean_data:
     benchmark:
         f"{logdir + bench}" + "QC_clean_data_{sample}.txt"
     threads: 6
+    resources:
+        memory = 12
     shell:
         """
 if [ -s "{input}" ] # If file exists and is NOT empty (i.e. filesize > 0) do...

--- a/bin/rules/ILM_Ref_RemovePrimers.smk
+++ b/bin/rules/ILM_Ref_RemovePrimers.smk
@@ -13,6 +13,8 @@ rule RemovePrimers_pt1:
     benchmark:
         f"{logdir + bench}" + "Illumina_RemovePrimers_pt1_{sample}.txt"
     threads: 1
+    resources:
+        memory = 4
     shell:
         """
 cat {input} > {output}

--- a/bin/rules/ILM_Ref_RemovePrimers.smk
+++ b/bin/rules/ILM_Ref_RemovePrimers.smk
@@ -14,7 +14,7 @@ rule RemovePrimers_pt1:
         f"{logdir + bench}" + "Illumina_RemovePrimers_pt1_{sample}.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     shell:
         """
 cat {input} > {output}
@@ -34,7 +34,7 @@ rule RemovePrimers_pt2:
         f"{logdir + bench}" + "Illumina_RemovePrimers_pt2_{sample}.txt"
     threads: config["threads"]["Illumina_RemovePrimers"]
     resources: 
-        memory = config["threads"]["Illumina_RemovePrimers"] * 12
+        memory = (config["threads"]["Illumina_RemovePrimers"] * 12) * 1024
     params:
         primer_status = prstatus
     shell:

--- a/bin/rules/ILM_Ref_RemovePrimers.smk
+++ b/bin/rules/ILM_Ref_RemovePrimers.smk
@@ -31,6 +31,8 @@ rule RemovePrimers_pt2:
     benchmark:
         f"{logdir + bench}" + "Illumina_RemovePrimers_pt2_{sample}.txt"
     threads: config["threads"]["Illumina_RemovePrimers"]
+    resources: 
+        memory = config["threads"]["Illumina_RemovePrimers"] * 12
     params:
         primer_status = prstatus
     shell:

--- a/bin/rules/ILM_Ref_align_to_ref_it1.smk
+++ b/bin/rules/ILM_Ref_align_to_ref_it1.smk
@@ -16,6 +16,8 @@ rule Illumina_align_to_reference_it1:
     benchmark:
         f"{logdir + bench}" + "Illumina_align_to_reference_it1_{sample}.txt"
     threads: config["threads"]["Illumina_align_to_reference"]
+    resources: 
+        memory = config["threads"]["Illumina_align_to_reference"] * 12
     params:
         aln_type        =   config["Illumina_ref"]["Alignment"]["Alignment_type"],
         remove_dups     =   config["Illumina_ref"]["Alignment"]["Duplicates"], #! Don't change this, see this gotcha with duplicate marked reads in bedtools genomecov (which is used downstream): https://groups.google.com/forum/#!msg/bedtools-discuss/wJNC2-icIb4/wflT6PnEHQAJ . bedtools genomecov is not able to filter them out and includes those dup-reads in it's coverage metrics. So the downstream BoC analysis and consensus at diff cov processes require dups to be HARD removed.

--- a/bin/rules/ILM_Ref_align_to_ref_it1.smk
+++ b/bin/rules/ILM_Ref_align_to_ref_it1.smk
@@ -17,7 +17,7 @@ rule Illumina_align_to_reference_it1:
         f"{logdir + bench}" + "Illumina_align_to_reference_it1_{sample}.txt"
     threads: config["threads"]["Illumina_align_to_reference"]
     resources: 
-        memory = config["threads"]["Illumina_align_to_reference"] * 12
+        memory = (config["threads"]["Illumina_align_to_reference"] * 12) * 1024
     params:
         aln_type        =   config["Illumina_ref"]["Alignment"]["Alignment_type"],
         remove_dups     =   config["Illumina_ref"]["Alignment"]["Duplicates"], #! Don't change this, see this gotcha with duplicate marked reads in bedtools genomecov (which is used downstream): https://groups.google.com/forum/#!msg/bedtools-discuss/wJNC2-icIb4/wflT6PnEHQAJ . bedtools genomecov is not able to filter them out and includes those dup-reads in it's coverage metrics. So the downstream BoC analysis and consensus at diff cov processes require dups to be HARD removed.

--- a/bin/rules/ILM_Ref_align_to_ref_it2.smk
+++ b/bin/rules/ILM_Ref_align_to_ref_it2.smk
@@ -18,7 +18,7 @@ rule Illumina_align_to_reference_it2:
         f"{logdir + bench}" + "Illumina_align_to_reference_it2_{sample}.txt"
     threads: config["threads"]["Illumina_align_to_reference"]
     resources: 
-        memory = config["threads"]["Illumina_align_to_reference"] * 12
+        memory = (config["threads"]["Illumina_align_to_reference"] * 12) * 1024
     params:
         aln_type        =   config["Illumina_ref"]["Alignment"]["Alignment_type"],
         remove_dups     =   config["Illumina_ref"]["Alignment"]["Duplicates"], #! Don't change this, see this gotcha with duplicate marked reads in bedtools genomecov (which is used downstream): https://groups.google.com/forum/#!msg/bedtools-discuss/wJNC2-icIb4/wflT6PnEHQAJ . bedtools genomecov is not able to filter them out and includes those dup-reads in it's coverage metrics. So the downstream BoC analysis and consensus at diff cov processes require dups to be HARD removed.

--- a/bin/rules/ILM_Ref_align_to_ref_it2.smk
+++ b/bin/rules/ILM_Ref_align_to_ref_it2.smk
@@ -17,6 +17,8 @@ rule Illumina_align_to_reference_it2:
     benchmark:
         f"{logdir + bench}" + "Illumina_align_to_reference_it2_{sample}.txt"
     threads: config["threads"]["Illumina_align_to_reference"]
+    resources: 
+        memory = config["threads"]["Illumina_align_to_reference"] * 12
     params:
         aln_type        =   config["Illumina_ref"]["Alignment"]["Alignment_type"],
         remove_dups     =   config["Illumina_ref"]["Alignment"]["Duplicates"], #! Don't change this, see this gotcha with duplicate marked reads in bedtools genomecov (which is used downstream): https://groups.google.com/forum/#!msg/bedtools-discuss/wJNC2-icIb4/wflT6PnEHQAJ . bedtools genomecov is not able to filter them out and includes those dup-reads in it's coverage metrics. So the downstream BoC analysis and consensus at diff cov processes require dups to be HARD removed.

--- a/bin/rules/ILM_Ref_boc_covs.smk
+++ b/bin/rules/ILM_Ref_boc_covs.smk
@@ -14,7 +14,7 @@ rule Illumina_determine_BoC_at_diff_cov_thresholds:
         f"{logdir + bench}" + "Illumina_determine_BoC_at_diff_cov_thresholds_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     shell:
         """
 bash bin/scripts/BoC_analysis.sh {wildcards.sample} {input.bedgraph} {input.reference} \

--- a/bin/rules/ILM_Ref_boc_covs.smk
+++ b/bin/rules/ILM_Ref_boc_covs.smk
@@ -13,6 +13,8 @@ rule Illumina_determine_BoC_at_diff_cov_thresholds:
     benchmark:
         f"{logdir + bench}" + "Illumina_determine_BoC_at_diff_cov_thresholds_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     shell:
         """
 bash bin/scripts/BoC_analysis.sh {wildcards.sample} {input.bedgraph} {input.reference} \

--- a/bin/rules/ILM_Ref_boc_mets.smk
+++ b/bin/rules/ILM_Ref_boc_mets.smk
@@ -19,7 +19,7 @@ rule Illumina_concat_BoC_metrics:
         f"{logdir + bench}Illumina_concat_BoC_metrics.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     shell:
         """
 echo -e "Sample_name\tTotal_ref_size\tBoC_at_coverage_threshold_1\tBoC_at_coverage_threshold_5\tBoC_at_coverage_threshold_10\tBoC_at_coverage_threshold_30\tBoC_at_coverage_threshold_100" > {output.combined_BoC_int_tsv}

--- a/bin/rules/ILM_Ref_boc_mets.smk
+++ b/bin/rules/ILM_Ref_boc_mets.smk
@@ -18,6 +18,8 @@ rule Illumina_concat_BoC_metrics:
     benchmark:
         f"{logdir + bench}Illumina_concat_BoC_metrics.txt"
     threads: 1
+    resources:
+        memory = 4
     shell:
         """
 echo -e "Sample_name\tTotal_ref_size\tBoC_at_coverage_threshold_1\tBoC_at_coverage_threshold_5\tBoC_at_coverage_threshold_10\tBoC_at_coverage_threshold_30\tBoC_at_coverage_threshold_100" > {output.combined_BoC_int_tsv}

--- a/bin/rules/ILM_Ref_concat-snips.smk
+++ b/bin/rules/ILM_Ref_concat-snips.smk
@@ -13,7 +13,7 @@ rule SNP_table:
         f"{logdir + bench}Concatenated_SNPs.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     shell:
         """
 echo -e "# The events below are incorporated into the consensus genome, depending on the INDELS versus the user-supplied reference these coordinates are not comparable to the generated consensus genome in the \"results/sequences/\" folder\nSample\tReference AccessionID\tPosition\tType\tReference\tAlternative\tQuality" > {output}

--- a/bin/rules/ILM_Ref_concat-snips.smk
+++ b/bin/rules/ILM_Ref_concat-snips.smk
@@ -12,6 +12,8 @@ rule SNP_table:
     benchmark:
         f"{logdir + bench}Concatenated_SNPs.txt"
     threads: 1
+    resources:
+        memory = 4
     shell:
         """
 echo -e "# The events below are incorporated into the consensus genome, depending on the INDELS versus the user-supplied reference these coordinates are not comparable to the generated consensus genome in the \"results/sequences/\" folder\nSample\tReference AccessionID\tPosition\tType\tReference\tAlternative\tQuality" > {output}

--- a/bin/rules/ILM_Ref_extract_clean_cons.smk
+++ b/bin/rules/ILM_Ref_extract_clean_cons.smk
@@ -28,7 +28,7 @@ rule Illumina_extract_clean_consensus:
         f"{logdir + bench}" + "Illumina_extract_clean_consensus_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     params:
         output_data_folder      =   f"{datadir + it2 + cons}",
         output_results_folder   =   f"{res + seqs}"

--- a/bin/rules/ILM_Ref_extract_clean_cons.smk
+++ b/bin/rules/ILM_Ref_extract_clean_cons.smk
@@ -27,6 +27,8 @@ rule Illumina_extract_clean_consensus:
     benchmark:
         f"{logdir + bench}" + "Illumina_extract_clean_consensus_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     params:
         output_data_folder      =   f"{datadir + it2 + cons}",
         output_results_folder   =   f"{res + seqs}"

--- a/bin/rules/ILM_Ref_extract_raw_cons_it1.smk
+++ b/bin/rules/ILM_Ref_extract_raw_cons_it1.smk
@@ -17,6 +17,8 @@ rule Illumina_extract_raw_consensus_it1:
     benchmark:
         f"{logdir + bench}" + "Illumina_extract_raw_consensus_it1_{sample}.txt"
     threads: config["threads"]["Illumina_extract_raw_consensus"]
+    resources: 
+        memory = config["threads"]["Illumina_extract_raw_consensus"] * 12
     params:
         max_cov             = config["Illumina_ref"]["SNP"]["Max_coverage"],
     shell: # First codeblock, SNP and indel calling, filter majority SNPs from LoFreq output, zip/normalize/index it, call consensus based on these SNPs.

--- a/bin/rules/ILM_Ref_extract_raw_cons_it1.smk
+++ b/bin/rules/ILM_Ref_extract_raw_cons_it1.smk
@@ -18,7 +18,7 @@ rule Illumina_extract_raw_consensus_it1:
         f"{logdir + bench}" + "Illumina_extract_raw_consensus_it1_{sample}.txt"
     threads: config["threads"]["Illumina_extract_raw_consensus"]
     resources: 
-        memory = config["threads"]["Illumina_extract_raw_consensus"] * 12
+        memory = (config["threads"]["Illumina_extract_raw_consensus"] * 12) * 1024
     params:
         max_cov             = config["Illumina_ref"]["SNP"]["Max_coverage"],
     shell: # First codeblock, SNP and indel calling, filter majority SNPs from LoFreq output, zip/normalize/index it, call consensus based on these SNPs.

--- a/bin/rules/ILM_Ref_extract_raw_cons_it2.smk
+++ b/bin/rules/ILM_Ref_extract_raw_cons_it2.smk
@@ -20,6 +20,8 @@ rule Illumina_extract_raw_consensus_it2:
     benchmark:
         f"{logdir + bench}" + "Illumina_extract_raw_consensus_it2_{sample}.txt"
     threads: config["threads"]["Illumina_extract_raw_consensus"]
+    resources: 
+        memory = config["threads"]["Illumina_extract_raw_consensus"] * 12
     params:
         max_cov             = config["Illumina_ref"]["SNP"]["Max_coverage"],
         min_AF              = config["Illumina_ref"]["SNP"]["Minority_SNP_AF_lower_threshold"]

--- a/bin/rules/ILM_Ref_extract_raw_cons_it2.smk
+++ b/bin/rules/ILM_Ref_extract_raw_cons_it2.smk
@@ -21,7 +21,7 @@ rule Illumina_extract_raw_consensus_it2:
         f"{logdir + bench}" + "Illumina_extract_raw_consensus_it2_{sample}.txt"
     threads: config["threads"]["Illumina_extract_raw_consensus"]
     resources: 
-        memory = config["threads"]["Illumina_extract_raw_consensus"] * 12
+        memory = (config["threads"]["Illumina_extract_raw_consensus"] * 12) * 1024
     params:
         max_cov             = config["Illumina_ref"]["SNP"]["Max_coverage"],
         min_AF              = config["Illumina_ref"]["SNP"]["Minority_SNP_AF_lower_threshold"]

--- a/bin/rules/ILM_Ref_igv_combi.smk
+++ b/bin/rules/ILM_Ref_igv_combi.smk
@@ -18,7 +18,7 @@ rule Illumina_HTML_IGVJs_generate_final:
         f"{logdir + bench}Illumina_HTML_IGVJs_generate_final.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     params:
         chunkpath       =   f"{fls + chunks}", 
         tab_basename    =   f"{datadir + html}2_tab_",

--- a/bin/rules/ILM_Ref_igv_combi.smk
+++ b/bin/rules/ILM_Ref_igv_combi.smk
@@ -17,6 +17,8 @@ rule Illumina_HTML_IGVJs_generate_final:
     benchmark:
         f"{logdir + bench}Illumina_HTML_IGVJs_generate_final.txt"
     threads: 1
+    resources:
+        memory = 4
     params:
         chunkpath       =   f"{fls + chunks}", 
         tab_basename    =   f"{datadir + html}2_tab_",

--- a/bin/rules/ILM_Ref_igv_vars.smk
+++ b/bin/rules/ILM_Ref_igv_vars.smk
@@ -18,7 +18,7 @@ rule Illumina_HTML_IGVJs_variable_parts:
         f"{logdir + bench}" + "Illumina_HTML_IGVJs_variable_parts_{sample}.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     shell:
         """
 bash bin/html/igvjs_write_tabs.sh {wildcards.sample} {output.tab_output}

--- a/bin/rules/ILM_Ref_igv_vars.smk
+++ b/bin/rules/ILM_Ref_igv_vars.smk
@@ -17,6 +17,8 @@ rule Illumina_HTML_IGVJs_variable_parts:
     benchmark:
         f"{logdir + bench}" + "Illumina_HTML_IGVJs_variable_parts_{sample}.txt"
     threads: 1
+    resources:
+        memory = 4
     shell:
         """
 bash bin/html/igvjs_write_tabs.sh {wildcards.sample} {output.tab_output}

--- a/bin/rules/ILM_Ref_index.smk
+++ b/bin/rules/ILM_Ref_index.smk
@@ -13,6 +13,8 @@ rule Illumina_index_reference:
     benchmark:
         f"{logdir + bench}Illumina_index_reference.txt"
     threads: 4
+    resources:
+        memory = 12
     shell: # The reference is copied to the hardcoded subdir to make it standardized and easily logged. Convert it to a two-line fasta for easier downstream processing, replace ambiguity nucleotides with an N to avoid errors downstream.
         """
 cat {input.reference} | seqtk seq - | sed '/^[^>]/s/[R|Y|W|S|M|K|H|B|V|D]/N/g' > {output.reference_copy} 2>> {log}

--- a/bin/rules/ILM_Ref_index.smk
+++ b/bin/rules/ILM_Ref_index.smk
@@ -14,7 +14,7 @@ rule Illumina_index_reference:
         f"{logdir + bench}Illumina_index_reference.txt"
     threads: 4
     resources:
-        memory = 12
+        memory = 12 * 1024
     shell: # The reference is copied to the hardcoded subdir to make it standardized and easily logged. Convert it to a two-line fasta for easier downstream processing, replace ambiguity nucleotides with an N to avoid errors downstream.
         """
 cat {input.reference} | seqtk seq - | sed '/^[^>]/s/[R|Y|W|S|M|K|H|B|V|D]/N/g' > {output.reference_copy} 2>> {log}

--- a/bin/rules/ILM_Ref_multiqc.smk
+++ b/bin/rules/ILM_Ref_multiqc.smk
@@ -43,6 +43,8 @@ rule Illumina_MultiQC_report:
     benchmark:
         f"{logdir + bench}Illumina_MultiQC_report.txt"
     threads: 1
+    resources:
+        memory = 8
     params:
         config_file =   f"{fls}multiqc_config.yaml",
         output_dir  =   f"{res}",

--- a/bin/rules/ILM_Ref_multiqc.smk
+++ b/bin/rules/ILM_Ref_multiqc.smk
@@ -44,7 +44,7 @@ rule Illumina_MultiQC_report:
         f"{logdir + bench}Illumina_MultiQC_report.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     params:
         config_file =   f"{fls}multiqc_config.yaml",
         output_dir  =   f"{res}",

--- a/bin/rules/KronaChart.smk
+++ b/bin/rules/KronaChart.smk
@@ -20,6 +20,8 @@ rule Krona_chart_combine:
     benchmark:
         f"{logdir + bench}Krona_chart_combine.txt"
     threads: 1
+    resources:
+        memory = 8
     params:
         krona_tax_db    =   config["databases"]["Krona_taxonomy"]
     shell:

--- a/bin/rules/KronaChart.smk
+++ b/bin/rules/KronaChart.smk
@@ -21,7 +21,7 @@ rule Krona_chart_combine:
         f"{logdir + bench}Krona_chart_combine.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     params:
         krona_tax_db    =   config["databases"]["Krona_taxonomy"]
     shell:

--- a/bin/rules/Krona_LCA.smk
+++ b/bin/rules/Krona_LCA.smk
@@ -12,6 +12,8 @@ rule Krona_chart_and_LCA:
     benchmark:
         f"{logdir + bench}" + "Krona_chart_and_LCA_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     params:
         bitscoreDelta   =   config["Illumina_meta"]["LCA"]["bitscoreDelta"],
         krona_tax_db    =   config["databases"]["Krona_taxonomy"]

--- a/bin/rules/Krona_LCA.smk
+++ b/bin/rules/Krona_LCA.smk
@@ -13,7 +13,7 @@ rule Krona_chart_and_LCA:
         f"{logdir + bench}" + "Krona_chart_and_LCA_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     params:
         bitscoreDelta   =   config["Illumina_meta"]["LCA"]["bitscoreDelta"],
         krona_tax_db    =   config["databases"]["Krona_taxonomy"]

--- a/bin/rules/Merge_metrics.smk
+++ b/bin/rules/Merge_metrics.smk
@@ -25,7 +25,7 @@ rule Merge_all_metrics_into_single_tsv:
         f"{logdir + bench}" + "Merge_all_metrics_into_single_tsv_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     shell:
         """
 python bin/scripts/merge_data.py {wildcards.sample} \

--- a/bin/rules/Merge_metrics.smk
+++ b/bin/rules/Merge_metrics.smk
@@ -24,6 +24,8 @@ rule Merge_all_metrics_into_single_tsv:
     benchmark:
         f"{logdir + bench}" + "Merge_all_metrics_into_single_tsv_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     shell:
         """
 python bin/scripts/merge_data.py {wildcards.sample} \

--- a/bin/rules/MultiQC.smk
+++ b/bin/rules/MultiQC.smk
@@ -42,7 +42,7 @@ rule MultiQC_report:
         f"{logdir + bench}MultiQC_report.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     params:
         config_file =   f"{fls}multiqc_config.yaml"
     shell:

--- a/bin/rules/MultiQC.smk
+++ b/bin/rules/MultiQC.smk
@@ -41,6 +41,8 @@ rule MultiQC_report:
     benchmark:
         f"{logdir + bench}MultiQC_report.txt"
     threads: 1
+    resources:
+        memory = 8
     params:
         config_file =   f"{fls}multiqc_config.yaml"
     shell:

--- a/bin/rules/Nano_Ref_Cleanup.smk
+++ b/bin/rules/Nano_Ref_Cleanup.smk
@@ -13,7 +13,7 @@ rule Cleanup:
         f"{logdir + bench}" + "Data_Cleanup_{sample}.txt"
     threads: config["threads"]["Nanopore_cleanup"]
     resources: 
-        memory = config["threads"]["Nanopore_cleanup"] * 10
+        memory = (config["threads"]["Nanopore_cleanup"] * 10) * 1024
     params:
         QualityFilter   =   config["Nanopore_ref"]["Quality_score"]
     shell:

--- a/bin/rules/Nano_Ref_Cleanup.smk
+++ b/bin/rules/Nano_Ref_Cleanup.smk
@@ -12,6 +12,8 @@ rule Cleanup:
     benchmark:
         f"{logdir + bench}" + "Data_Cleanup_{sample}.txt"
     threads: config["threads"]["Nanopore_cleanup"]
+    resources: 
+        memory = config["threads"]["Nanopore_cleanup"] * 12
     params:
         QualityFilter   =   config["Nanopore_ref"]["Quality_score"]
     shell:

--- a/bin/rules/Nano_Ref_Cleanup.smk
+++ b/bin/rules/Nano_Ref_Cleanup.smk
@@ -13,7 +13,7 @@ rule Cleanup:
         f"{logdir + bench}" + "Data_Cleanup_{sample}.txt"
     threads: config["threads"]["Nanopore_cleanup"]
     resources: 
-        memory = config["threads"]["Nanopore_cleanup"] * 12
+        memory = config["threads"]["Nanopore_cleanup"] * 10
     params:
         QualityFilter   =   config["Nanopore_ref"]["Quality_score"]
     shell:

--- a/bin/rules/Nano_Ref_Cut-primers.smk
+++ b/bin/rules/Nano_Ref_Cut-primers.smk
@@ -12,7 +12,7 @@ rule Cut_primers:
         f"{logdir + bench}" + "Primer_removal_{sample}.txt"
     threads: config["threads"]["Nanopore_primer_removal"]
     resources: 
-        memory = config["threads"]["Nanopore_primer_removal"] * 12
+        memory = (config["threads"]["Nanopore_primer_removal"] * 12) * 1024
     shell:
         """
 python bin/scripts/RemoveONTPrimers.py --input {input.fastq} --reference {input.ref} --primers {input.primers} --threads {threads} --output {output}

--- a/bin/rules/Nano_Ref_Cut-primers.smk
+++ b/bin/rules/Nano_Ref_Cut-primers.smk
@@ -11,6 +11,8 @@ rule Cut_primers:
     benchmark:
         f"{logdir + bench}" + "Primer_removal_{sample}.txt"
     threads: config["threads"]["Nanopore_primer_removal"]
+    resources: 
+        memory = config["threads"]["Nanopore_primer_removal"] * 12
     shell:
         """
 python bin/scripts/RemoveONTPrimers.py --input {input.fastq} --reference {input.ref} --primers {input.primers} --threads {threads} --output {output}

--- a/bin/rules/Nano_Ref_GC-content.smk
+++ b/bin/rules/Nano_Ref_GC-content.smk
@@ -16,7 +16,7 @@ rule determine_GC_content:
         f"{logdir + bench}Determine_GC_content.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     params:
         window_size =   config["Global"]["GC_window_size"]
     shell:

--- a/bin/rules/Nano_Ref_GC-content.smk
+++ b/bin/rules/Nano_Ref_GC-content.smk
@@ -15,6 +15,8 @@ rule determine_GC_content:
     benchmark:
         f"{logdir + bench}Determine_GC_content.txt"
     threads: 1
+    resources:
+        memory = 8
     params:
         window_size =   config["Global"]["GC_window_size"]
     shell:

--- a/bin/rules/Nano_Ref_IGVjs.smk
+++ b/bin/rules/Nano_Ref_IGVjs.smk
@@ -52,7 +52,7 @@ rule HTML_IGVJs_generate_file:
         f"{logdir + bench}HTML_IGVJs_generate_file.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     params:
         tab_basename    =   f"{datadir + chunks}2_tab_",
         div_basename    =   f"{datadir + chunks}4_html_divs_",

--- a/bin/rules/Nano_Ref_IGVjs.smk
+++ b/bin/rules/Nano_Ref_IGVjs.smk
@@ -19,6 +19,8 @@ rule HTML_IGVJs_variable_parts:
     benchmark:
         f"{logdir + bench}" + "HTML_IGVJs_variable_parts_{sample}.txt"
     threads: 1
+    resources:
+        memory = 4
     shell:
         """
 bash bin/html/igvjs_write_tabs.sh {wildcards.sample} {output.tab}
@@ -49,6 +51,8 @@ rule HTML_IGVJs_generate_file:
     benchmark:
         f"{logdir + bench}HTML_IGVJs_generate_file.txt"
     threads: 1
+    resources:
+        memory = 4
     params:
         tab_basename    =   f"{datadir + chunks}2_tab_",
         div_basename    =   f"{datadir + chunks}4_html_divs_",

--- a/bin/rules/Nano_Ref_MultiQC.smk
+++ b/bin/rules/Nano_Ref_MultiQC.smk
@@ -21,6 +21,8 @@ rule MultiQC_report:
     benchmark:
         f"{logdir + bench}MultiQC_report.txt"
     threads: 1
+    resources:
+        memory = 12
     params:
         config_file = "files/multiqc_config.yaml",
         output_dir = res,

--- a/bin/rules/Nano_Ref_MultiQC.smk
+++ b/bin/rules/Nano_Ref_MultiQC.smk
@@ -22,7 +22,7 @@ rule MultiQC_report:
         f"{logdir + bench}MultiQC_report.txt"
     threads: 1
     resources:
-        memory = 12
+        memory = 12 * 1024
     params:
         config_file = "files/multiqc_config.yaml",
         output_dir = res,

--- a/bin/rules/Nano_Ref_ORF-analysis.smk
+++ b/bin/rules/Nano_Ref_ORF-analysis.smk
@@ -17,7 +17,7 @@ rule ORF_Analysis:
         f"{logdir + bench}ORF_Analysis.txt"
     threads: 1
     resources:
-        memory = 12
+        memory = 12 * 1024
     params:
         procedure       =   config["Global"]["ORF_procedure"],
         output_format   =   config["Global"]["ORF_output_format"]

--- a/bin/rules/Nano_Ref_ORF-analysis.smk
+++ b/bin/rules/Nano_Ref_ORF-analysis.smk
@@ -16,6 +16,8 @@ rule ORF_Analysis:
     benchmark:
         f"{logdir + bench}ORF_Analysis.txt"
     threads: 1
+    resources:
+        memory = 12
     params:
         procedure       =   config["Global"]["ORF_procedure"],
         output_format   =   config["Global"]["ORF_output_format"]

--- a/bin/rules/Nano_Ref_RemoveAdapters.smk
+++ b/bin/rules/Nano_Ref_RemoveAdapters.smk
@@ -16,7 +16,7 @@ rule Remove_Adapters_pt1:
         f"{logdir + bench}" + "Remove_Adapters_pt1_{sample}.txt"
     threads: config["threads"]["Nanopore_reference_alignment"]
     resources: 
-        memory = config["threads"]["Nanopore_reference_alignment"] * 12
+        memory = (config["threads"]["Nanopore_reference_alignment"] * 12) * 1024
     params:
         mapthreads = mappingthreads
     shell: 
@@ -38,7 +38,7 @@ rule Remove_Adapters_pt2:
         f"{logdir + bench}" + "Remove_Adapters_pt2_{sample}.txt"
     threads: config["threads"]["Nanopore_SoftClipper"]
     resources:
-        memory = 12
+        memory = 12 * 1024
     shell: 
         """
 python bin/scripts/SoftClipper.py --input {input} --output {output} --threads {threads}

--- a/bin/rules/Nano_Ref_RemoveAdapters.smk
+++ b/bin/rules/Nano_Ref_RemoveAdapters.smk
@@ -15,6 +15,8 @@ rule Remove_Adapters_pt1:
     benchmark:
         f"{logdir + bench}" + "Remove_Adapters_pt1_{sample}.txt"
     threads: config["threads"]["Nanopore_reference_alignment"]
+    resources: 
+        memory = config["threads"]["Nanopore_reference_alignment"] * 12
     params:
         mapthreads = mappingthreads
     shell: 

--- a/bin/rules/Nano_Ref_RemoveAdapters.smk
+++ b/bin/rules/Nano_Ref_RemoveAdapters.smk
@@ -37,6 +37,8 @@ rule Remove_Adapters_pt2:
     benchmark:
         f"{logdir + bench}" + "Remove_Adapters_pt2_{sample}.txt"
     threads: config["threads"]["Nanopore_SoftClipper"]
+    resources:
+        memory = 12
     shell: 
         """
 python bin/scripts/SoftClipper.py --input {input} --output {output} --threads {threads}

--- a/bin/rules/Nano_Ref_alignment_pt1.smk
+++ b/bin/rules/Nano_Ref_alignment_pt1.smk
@@ -17,7 +17,7 @@ rule Align_to_reference_pt1:
         f"{logdir + bench}" + "Align_to_reference_pt1_{sample}.txt"
     threads: config["threads"]["Nanopore_reference_alignment"]
     resources: 
-        memory = config["threads"]["Nanopore_reference_alignment"] * 12
+        memory = (config["threads"]["Nanopore_reference_alignment"] * 12) * 1024
     params:
         mapthreads = mappingthreads
     shell:

--- a/bin/rules/Nano_Ref_alignment_pt1.smk
+++ b/bin/rules/Nano_Ref_alignment_pt1.smk
@@ -16,6 +16,8 @@ rule Align_to_reference_pt1:
     benchmark:
         f"{logdir + bench}" + "Align_to_reference_pt1_{sample}.txt"
     threads: config["threads"]["Nanopore_reference_alignment"]
+    resources: 
+        memory = config["threads"]["Nanopore_reference_alignment"] * 12
     params:
         mapthreads = mappingthreads
     shell:

--- a/bin/rules/Nano_Ref_alignment_pt2.smk
+++ b/bin/rules/Nano_Ref_alignment_pt2.smk
@@ -17,6 +17,8 @@ rule Align_to_reference_pt2:
     benchmark:
         f"{logdir + bench}" + "Align_to_reference_pt2_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     shell:
         """
 bcftools mpileup --ignore-RG -Ou -d 10000 -f {input.ref} {input.bam} 2>> {log} |\

--- a/bin/rules/Nano_Ref_alignment_pt2.smk
+++ b/bin/rules/Nano_Ref_alignment_pt2.smk
@@ -18,7 +18,7 @@ rule Align_to_reference_pt2:
         f"{logdir + bench}" + "Align_to_reference_pt2_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     shell:
         """
 bcftools mpileup --ignore-RG -Ou -d 10000 -f {input.ref} {input.bam} 2>> {log} |\

--- a/bin/rules/Nano_Ref_calc-boc.smk
+++ b/bin/rules/Nano_Ref_calc-boc.smk
@@ -16,7 +16,7 @@ rule calculate_BoC:
         f"{logdir + bench}" + "Calculate_boc_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     shell:
         """
 bash bin/scripts/BoC_analysis.sh {wildcards.sample} {input.bedgraph} {input.reference} \

--- a/bin/rules/Nano_Ref_calc-boc.smk
+++ b/bin/rules/Nano_Ref_calc-boc.smk
@@ -15,6 +15,8 @@ rule calculate_BoC:
     benchmark:
         f"{logdir + bench}" + "Calculate_boc_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     shell:
         """
 bash bin/scripts/BoC_analysis.sh {wildcards.sample} {input.bedgraph} {input.reference} \

--- a/bin/rules/Nano_Ref_concat-boc.smk
+++ b/bin/rules/Nano_Ref_concat-boc.smk
@@ -21,6 +21,8 @@ rule concat_boc:
     benchmark:
         f"{logdir + bench}Concat_boc.txt"
     threads: 1
+    resources:
+        memory = 6
     shell:
         """
 echo -e "Sample_name\tTotal_ref_size\tBoC_at_coverage_threshold_1\tBoC_at_coverage_threshold_5\tBoC_at_coverage_threshold_10\tBoC_at_coverage_threshold_30\tBoC_at_coverage_threshold_100" > {output.conc_boc_int}

--- a/bin/rules/Nano_Ref_concat-boc.smk
+++ b/bin/rules/Nano_Ref_concat-boc.smk
@@ -22,7 +22,7 @@ rule concat_boc:
         f"{logdir + bench}Concat_boc.txt"
     threads: 1
     resources:
-        memory = 6
+        memory = 6 * 1024
     shell:
         """
 echo -e "Sample_name\tTotal_ref_size\tBoC_at_coverage_threshold_1\tBoC_at_coverage_threshold_5\tBoC_at_coverage_threshold_10\tBoC_at_coverage_threshold_30\tBoC_at_coverage_threshold_100" > {output.conc_boc_int}

--- a/bin/rules/Nano_Ref_concat-snips.smk
+++ b/bin/rules/Nano_Ref_concat-snips.smk
@@ -12,7 +12,7 @@ rule SNP_table:
         f"{logdir + bench}Concatenated_SNPs.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     shell:
         """
 echo -e "Sample\tReference AccessionID\tPosition\tType\tReference\tAlternative\tQuality" > {output}
@@ -32,7 +32,7 @@ rule concat_ins:
         f"{logdir + bench}concat_ins.txt"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     shell:
         """
 echo -e "Sample\tHas Insertions?\tPositions\tPercentage of reads" > {output}

--- a/bin/rules/Nano_Ref_concat-snips.smk
+++ b/bin/rules/Nano_Ref_concat-snips.smk
@@ -11,6 +11,8 @@ rule SNP_table:
     benchmark:
         f"{logdir + bench}Concatenated_SNPs.txt"
     threads: 1
+    resources:
+        memory = 4
     shell:
         """
 echo -e "Sample\tReference AccessionID\tPosition\tType\tReference\tAlternative\tQuality" > {output}
@@ -29,6 +31,8 @@ rule concat_ins:
     benchmark:
         f"{logdir + bench}concat_ins.txt"
     threads: 1
+    resources:
+        memory = 4
     shell:
         """
 echo -e "Sample\tHas Insertions?\tPositions\tPercentage of reads" > {output}

--- a/bin/rules/Nano_Ref_concat_seqs.smk
+++ b/bin/rules/Nano_Ref_concat_seqs.smk
@@ -34,7 +34,7 @@ rule concat_seqs_standard:
         wildcard_100    =   f"{res + seqs}" + "*_standard_cov_ge_100.fa"
     threads: 1
     resources:
-        memory = 6
+        memory = 6 * 1024
     shell:
         """
 cat {params.wildcard_1} >> {output.conc_1}
@@ -81,7 +81,7 @@ rule concat_seqs_gapcorrected:
         wildcard_100    =   f"{res + seqs}" + "*_gap_corrected_cov_ge_100.fa"
     threads: 1
     resources:
-        memory = 6
+        memory = 6 * 1024
     shell:
         """
 cat {params.wildcard_1} >> {output.conc_1}

--- a/bin/rules/Nano_Ref_concat_seqs.smk
+++ b/bin/rules/Nano_Ref_concat_seqs.smk
@@ -32,6 +32,9 @@ rule concat_seqs_standard:
         wildcard_10     =   f"{res + seqs}" + "*_standard_cov_ge_10.fa",
         wildcard_30     =   f"{res + seqs}" + "*_standard_cov_ge_30.fa",
         wildcard_100    =   f"{res + seqs}" + "*_standard_cov_ge_100.fa"
+    threads: 1
+    resources:
+        memory = 6
     shell:
         """
 cat {params.wildcard_1} >> {output.conc_1}
@@ -76,6 +79,9 @@ rule concat_seqs_gapcorrected:
         wildcard_10     =   f"{res + seqs}" + "*_gap_corrected_cov_ge_10.fa",
         wildcard_30     =   f"{res + seqs}" + "*_gap_corrected_cov_ge_30.fa",
         wildcard_100    =   f"{res + seqs}" + "*_gap_corrected_cov_ge_100.fa"
+    threads: 1
+    resources:
+        memory = 6
     shell:
         """
 cat {params.wildcard_1} >> {output.conc_1}

--- a/bin/rules/Nano_Ref_consensus.smk
+++ b/bin/rules/Nano_Ref_consensus.smk
@@ -19,7 +19,7 @@ rule consensus_cov_1:
         f"{logdir + bench}" + "Generate_consensus_{sample}.txt"
     threads: 2
     resources:
-        memory = 24
+        memory = 24 * 1024
     shell:
         """
 python bin/scripts/Consensus.py \
@@ -56,7 +56,7 @@ rule consensus_cov_5:
         f"{logdir + bench}" + "Generate_consensus_{sample}.txt"
     threads: 2
     resources:
-        memory = 24
+        memory = 24 * 1024
     shell:
         """
 python bin/scripts/Consensus.py \
@@ -92,7 +92,7 @@ rule consensus_cov_10:
         f"{logdir + bench}" + "Generate_consensus_{sample}.txt"
     threads: 2
     resources:
-        memory = 24
+        memory = 24 * 1024
     shell:
         """
 python bin/scripts/Consensus.py \
@@ -129,7 +129,7 @@ rule consensus_cov_30:
         f"{logdir + bench}" + "Generate_consensus_{sample}.txt"
     threads: 2
     resources:
-        memory = 24
+        memory = 24 * 1024
     shell:
         """
 python bin/scripts/Consensus.py \
@@ -165,7 +165,7 @@ rule consensus_cov_100:
         f"{logdir + bench}" + "Generate_consensus_{sample}.txt"
     threads: 2
     resources:
-        memory = 24
+        memory = 24 * 1024
     shell:
         """
 python bin/scripts/Consensus.py \

--- a/bin/rules/Nano_Ref_consensus.smk
+++ b/bin/rules/Nano_Ref_consensus.smk
@@ -18,6 +18,8 @@ rule consensus_cov_1:
     benchmark:
         f"{logdir + bench}" + "Generate_consensus_{sample}.txt"
     threads: 2
+    resources:
+        memory = 24
     shell:
         """
 python bin/scripts/Consensus.py \
@@ -53,6 +55,8 @@ rule consensus_cov_5:
     benchmark:
         f"{logdir + bench}" + "Generate_consensus_{sample}.txt"
     threads: 2
+    resources:
+        memory = 24
     shell:
         """
 python bin/scripts/Consensus.py \
@@ -87,6 +91,8 @@ rule consensus_cov_10:
     benchmark:
         f"{logdir + bench}" + "Generate_consensus_{sample}.txt"
     threads: 2
+    resources:
+        memory = 24
     shell:
         """
 python bin/scripts/Consensus.py \
@@ -122,6 +128,8 @@ rule consensus_cov_30:
     benchmark:
         f"{logdir + bench}" + "Generate_consensus_{sample}.txt"
     threads: 2
+    resources:
+        memory = 24
     shell:
         """
 python bin/scripts/Consensus.py \
@@ -156,6 +164,8 @@ rule consensus_cov_100:
     benchmark:
         f"{logdir + bench}" + "Generate_consensus_{sample}.txt"
     threads: 2
+    resources:
+        memory = 24
     shell:
         """
 python bin/scripts/Consensus.py \

--- a/bin/rules/Nano_Ref_coverage.smk
+++ b/bin/rules/Nano_Ref_coverage.smk
@@ -10,6 +10,8 @@ rule genomecoverage:
     benchmark:
         f"{logdir + bench}" + "Determine_genome_coverage_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     shell:
         """
 bedtools genomecov -bga -ibam {input.bam} > {output.bedgraph} 2>> {log}

--- a/bin/rules/Nano_Ref_coverage.smk
+++ b/bin/rules/Nano_Ref_coverage.smk
@@ -11,7 +11,7 @@ rule genomecoverage:
         f"{logdir + bench}" + "Determine_genome_coverage_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     shell:
         """
 bedtools genomecov -bga -ibam {input.bam} > {output.bedgraph} 2>> {log}

--- a/bin/rules/Nano_Ref_get_primers.smk
+++ b/bin/rules/Nano_Ref_get_primers.smk
@@ -8,7 +8,7 @@ rule Prepare_primers:
         f"{conda_envs}Nano_clean.yaml"
     threads: 1
     resources:
-        memory = 4
+        memory = 4 * 1024
     shell:
         """
 cp {input} {output.primers}

--- a/bin/rules/Nano_Ref_get_primers.smk
+++ b/bin/rules/Nano_Ref_get_primers.smk
@@ -7,6 +7,8 @@ rule Prepare_primers:
     conda:
         f"{conda_envs}Nano_clean.yaml"
     threads: 1
+    resources:
+        memory = 4
     shell:
         """
 cp {input} {output.primers}

--- a/bin/rules/Nano_Ref_index.smk
+++ b/bin/rules/Nano_Ref_index.smk
@@ -11,6 +11,8 @@ rule Index_ref:
     benchmark:
         f"{logdir + bench}Index_ref.txt"
     threads: 4
+    resources:
+        memory = 8
     shell:
         """
 cat {input.ref} | seqkit replace -p "\-" -s -r "N" > {output.refcopy}

--- a/bin/rules/Nano_Ref_index.smk
+++ b/bin/rules/Nano_Ref_index.smk
@@ -12,7 +12,7 @@ rule Index_ref:
         f"{logdir + bench}Index_ref.txt"
     threads: 4
     resources:
-        memory = 8
+        memory = 8 * 1024
     shell:
         """
 cat {input.ref} | seqkit replace -p "\-" -s -r "N" > {output.refcopy}

--- a/bin/rules/Nano_Ref_post-qc.smk
+++ b/bin/rules/Nano_Ref_post-qc.smk
@@ -11,6 +11,8 @@ rule cleaned_quality_control:
     benchmark:
         f"{logdir + bench}" + "cleaned_quality_control_{sample}.txt"
     threads: config["threads"]["Nanopore_QC"]
+    resources:
+        memory = config["threads"]["Nanopore_QC"] * 4
     params:
         outdir  =   f"{datadir + qc_post}"
     shell:

--- a/bin/rules/Nano_Ref_post-qc.smk
+++ b/bin/rules/Nano_Ref_post-qc.smk
@@ -12,7 +12,7 @@ rule cleaned_quality_control:
         f"{logdir + bench}" + "cleaned_quality_control_{sample}.txt"
     threads: config["threads"]["Nanopore_QC"]
     resources:
-        memory = config["threads"]["Nanopore_QC"] * 4
+        memory = (config["threads"]["Nanopore_QC"] * 4) * 1024
     params:
         outdir  =   f"{datadir + qc_post}"
     shell:

--- a/bin/rules/Nano_Ref_pre_qc.smk
+++ b/bin/rules/Nano_Ref_pre_qc.smk
@@ -11,6 +11,8 @@ rule raw_quality_control:
     benchmark:
         f"{logdir + bench}" + "raw_quality_control_{sample}.txt"
     threads: config["threads"]["Nanopore_QC"]
+    resources:
+        memory = config["threads"]["Nanopore_QC"] * 4
     params:
         output_dir  =   f"{datadir + qc_pre}"
     shell:

--- a/bin/rules/Nano_Ref_pre_qc.smk
+++ b/bin/rules/Nano_Ref_pre_qc.smk
@@ -12,7 +12,7 @@ rule raw_quality_control:
         f"{logdir + bench}" + "raw_quality_control_{sample}.txt"
     threads: config["threads"]["Nanopore_QC"]
     resources:
-        memory = config["threads"]["Nanopore_QC"] * 4
+        memory = (config["threads"]["Nanopore_QC"] * 4) * 1024
     params:
         output_dir  =   f"{datadir + qc_pre}"
     shell:

--- a/bin/rules/ORF_analysis.smk
+++ b/bin/rules/ORF_analysis.smk
@@ -21,6 +21,8 @@ rule ORF_analysis:
     benchmark:
         f"{logdir + bench}" + "ORF_prediction_{sample}.txt"
     threads: 1
+    resources:
+        memory = 8
     params:
         procedure       =   config["Global"]["ORF_procedure"],
         output_format   =   config["Global"]["ORF_output_format"]

--- a/bin/rules/ORF_analysis.smk
+++ b/bin/rules/ORF_analysis.smk
@@ -22,7 +22,7 @@ rule ORF_analysis:
         f"{logdir + bench}" + "ORF_prediction_{sample}.txt"
     threads: 1
     resources:
-        memory = 8
+        memory = 8 * 1024
     params:
         procedure       =   config["Global"]["ORF_procedure"],
         output_format   =   config["Global"]["ORF_output_format"]

--- a/bin/rules/QC_clean.smk
+++ b/bin/rules/QC_clean.smk
@@ -17,6 +17,8 @@ rule QC_clean_data:
     benchmark:
         f"{logdir + bench}" + "QC_clean_data_{sample}_{read}.txt"
     threads: 6
+    resources:
+        memory = 24
     shell:
         """
 if [ -s "{input}" ] # If file exists and is NOT empty (i.e. filesize > 0) do...

--- a/bin/rules/QC_clean.smk
+++ b/bin/rules/QC_clean.smk
@@ -18,7 +18,7 @@ rule QC_clean_data:
         f"{logdir + bench}" + "QC_clean_data_{sample}_{read}.txt"
     threads: 6
     resources:
-        memory = 24
+        memory = 24 * 1024
     shell:
         """
 if [ -s "{input}" ] # If file exists and is NOT empty (i.e. filesize > 0) do...

--- a/bin/rules/QC_raw.smk
+++ b/bin/rules/QC_raw.smk
@@ -17,6 +17,8 @@ rule QC_raw_data:
     benchmark:
         f"{logdir + bench}" + "QC_raw_data_{sample}_{read}.txt"
     threads: 6
+    resources:
+        memory = 24
     params:
         output_dir  =   f"{datadir + qc_pre}"
     shell:

--- a/bin/rules/QC_raw.smk
+++ b/bin/rules/QC_raw.smk
@@ -18,7 +18,7 @@ rule QC_raw_data:
         f"{logdir + bench}" + "QC_raw_data_{sample}_{read}.txt"
     threads: 6
     resources:
-        memory = 24
+        memory = 24 * 1024
     params:
         output_dir  =   f"{datadir + qc_pre}"
     shell:

--- a/bin/rules/Quantify.smk
+++ b/bin/rules/Quantify.smk
@@ -30,6 +30,8 @@ rule quantify_output:
     benchmark:
         f"{logdir + bench}quantify_output.txt"
     threads: config["threads"]["quantify_output"]
+    resources:
+        memory = config["threads"]["quantify_output"] * 4
     shell:
         """
 python bin/scripts/quantify_profiles.py \

--- a/bin/rules/Quantify.smk
+++ b/bin/rules/Quantify.smk
@@ -31,7 +31,7 @@ rule quantify_output:
         f"{logdir + bench}quantify_output.txt"
     threads: config["threads"]["quantify_output"]
     resources:
-        memory = config["threads"]["quantify_output"] * 4
+        memory = (config["threads"]["quantify_output"] * 4) * 1024
     shell:
         """
 python bin/scripts/quantify_profiles.py \

--- a/bin/rules/Read2scaffold_alignment_with_rmDup_and_fraglength.smk
+++ b/bin/rules/Read2scaffold_alignment_with_rmDup_and_fraglength.smk
@@ -22,6 +22,8 @@ rule Read2scaffold_alignment_with_rmDup_and_fraglength:
     benchmark:
         f"{logdir + bench}" + "Read2scaffold_alignment_with_rmDup_and_fraglength_{sample}.txt"
     threads: config["threads"]["Fragment_length_analysis"]
+    resources:
+        memory = config["threads"]["Fragment_length_analysis"] * 6
     params:
         remove_dups     =   "-r", #! This will HARD remove the duplicates instead of only marking them, N.B. this is REQUIRED for the downstream bbtools' pileup.sh to work --> it ignores the DUP marker and counts the reads in its coverage metrics. Thus giving a false sense of confidence.
         markdup_mode    =   "t",

--- a/bin/rules/Read2scaffold_alignment_with_rmDup_and_fraglength.smk
+++ b/bin/rules/Read2scaffold_alignment_with_rmDup_and_fraglength.smk
@@ -23,7 +23,7 @@ rule Read2scaffold_alignment_with_rmDup_and_fraglength:
         f"{logdir + bench}" + "Read2scaffold_alignment_with_rmDup_and_fraglength_{sample}.txt"
     threads: config["threads"]["Fragment_length_analysis"]
     resources:
-        memory = config["threads"]["Fragment_length_analysis"] * 6
+        memory = (config["threads"]["Fragment_length_analysis"] * 6) * 1024
     params:
         remove_dups     =   "-r", #! This will HARD remove the duplicates instead of only marking them, N.B. this is REQUIRED for the downstream bbtools' pileup.sh to work --> it ignores the DUP marker and counts the reads in its coverage metrics. Thus giving a false sense of confidence.
         markdup_mode    =   "t",

--- a/bin/rules/Read2scaffold_alignment_without_rmDup_and_fraglength.smk
+++ b/bin/rules/Read2scaffold_alignment_without_rmDup_and_fraglength.smk
@@ -23,7 +23,7 @@ rule Read2scaffold_alignment_without_rmDup_and_fraglength:
         f"{logdir + bench}" + "Read2scaffold_alignment_without_rmDup_and_fraglength_{sample}.txt"
     threads: config["threads"]["Fragment_length_analysis"]
     resources:
-        memory = config["threads"]["Fragment_length_analysis"] * 6
+        memory = (config["threads"]["Fragment_length_analysis"] * 6) * 1024
     shell:
         """
 bwa index {input.fasta} > {log} 2>&1

--- a/bin/rules/Read2scaffold_alignment_without_rmDup_and_fraglength.smk
+++ b/bin/rules/Read2scaffold_alignment_without_rmDup_and_fraglength.smk
@@ -22,6 +22,8 @@ rule Read2scaffold_alignment_without_rmDup_and_fraglength:
     benchmark:
         f"{logdir + bench}" + "Read2scaffold_alignment_without_rmDup_and_fraglength_{sample}.txt"
     threads: config["threads"]["Fragment_length_analysis"]
+    resources:
+        memory = config["threads"]["Fragment_length_analysis"] * 6
     shell:
         """
 bwa index {input.fasta} > {log} 2>&1

--- a/bin/rules/SNP_calling.smk
+++ b/bin/rules/SNP_calling.smk
@@ -23,7 +23,7 @@ rule SNP_calling:
         f"{logdir + bench}" + "SNP_calling_{sample}.txt"
     threads: config["threads"]["SNP_calling"]
     resources: 
-        memory = config["threads"]["SNP_calling"] * 8
+        memory = (config["threads"]["SNP_calling"] * 8) * 1024
     params:
         max_cov     =   config["Illumina_meta"]["SNP"]["Max_coverage"],
         minimum_AF  =   config["Illumina_meta"]["SNP"]["Minimum_AF"]

--- a/bin/rules/SNP_calling.smk
+++ b/bin/rules/SNP_calling.smk
@@ -23,7 +23,7 @@ rule SNP_calling:
         f"{logdir + bench}" + "SNP_calling_{sample}.txt"
     threads: config["threads"]["SNP_calling"]
     resources: 
-        memory = config["threads"]["SNP_calling"] * 12
+        memory = config["threads"]["SNP_calling"] * 8
     params:
         max_cov     =   config["Illumina_meta"]["SNP"]["Max_coverage"],
         minimum_AF  =   config["Illumina_meta"]["SNP"]["Minimum_AF"]

--- a/bin/rules/SNP_calling.smk
+++ b/bin/rules/SNP_calling.smk
@@ -22,6 +22,8 @@ rule SNP_calling:
     benchmark:
         f"{logdir + bench}" + "SNP_calling_{sample}.txt"
     threads: config["threads"]["SNP_calling"]
+    resources: 
+        memory = config["threads"]["SNP_calling"] * 12
     params:
         max_cov     =   config["Illumina_meta"]["SNP"]["Max_coverage"],
         minimum_AF  =   config["Illumina_meta"]["SNP"]["Minimum_AF"]

--- a/bin/rules/assembly.smk
+++ b/bin/rules/assembly.smk
@@ -20,7 +20,7 @@ rule De_novo_assembly:
         f"{logdir + bench}" + "De_novo_assembly_{sample}.txt"
     threads: config["threads"]["De_novo_assembly"]
     resources: 
-        memory = config["threads"]["De_novo_assembly"] * 12
+        memory = (config["threads"]["De_novo_assembly"] * 12) * 1024
     params:
         max_GB_RAM          =   config["Illumina_meta"]["Spades"]["Max_gb_ram"],
         kmersizes           =   config["Illumina_meta"]["Spades"]["kmersizes"],

--- a/bin/rules/assembly.smk
+++ b/bin/rules/assembly.smk
@@ -19,6 +19,8 @@ rule De_novo_assembly:
     benchmark:
         f"{logdir + bench}" + "De_novo_assembly_{sample}.txt"
     threads: config["threads"]["De_novo_assembly"]
+    resources: 
+        memory = config["threads"]["De_novo_assembly"] * 12
     params:
         max_GB_RAM          =   config["Illumina_meta"]["Spades"]["Max_gb_ram"],
         kmersizes           =   config["Illumina_meta"]["Spades"]["kmersizes"],

--- a/bin/rules/mgkit_LCA.smk
+++ b/bin/rules/mgkit_LCA.smk
@@ -116,7 +116,7 @@ rule lca_mgkit:
         f"{logdir + bench}" + "lca_mgkit_{sample}.txt"
     threads: 1
     resources:
-        memory = 12
+        memory = 12 * 1024
     shell:
         """
 taxon-utils lca -b {params.bitscore_threshold} -s -p -n {output.no_lca} -t {params.mgkit_tax_db}taxonomy.pickle {input.filtgff} {output.taxtab} > {log} 2>&1;


### PR DESCRIPTION
Add minor changes to request certain memory resources in grid mode. This should not interfere with local mode as snakemake automatically dials resources down to availability on a local system.

We currently use fixed memory resource requirements. However, we're still exploring the option of flexibible memory resources based on input files.