### PR TITLE
Create helper environment via mamba

### DIFF
--- a/bin/includes/Databases
+++ b/bin/includes/Databases
@@ -11,7 +11,7 @@ if [[ $PATH != *${HELPER_NAME}* ]]; then # If helper env is not in your path (i.
 
     if ! conda activate "${HELPER_NAME}"; then # If exit statement is not 0, i.e. helper conda env hasn't been installed yet, do...
         echo -e "\tInstalling Jovian helper environment..."
-        conda env create -f ${PATH_JOVIAN_HELPER_YAML} # Create the env from the specified yaml file
+        mamba env create -f ${PATH_JOVIAN_HELPER_YAML} # Create the env from the specified yaml file
         set -o allexport
 		conda activate "${HELPER_NAME}"
 		set +o allexport


### PR DESCRIPTION
Hey y'all,

I was helping our two Avans students (Bob van Rijthoven, Diemo Perre) get Jovian setup and they'd been stuck on conda resolution. On a previous installation it'd gone very well, but, we needed to reconfigure and reinstall and it stuck for days at a time on creating the Jovian_helper_env. I didn't see anything obvious slowing down the resolution, but on running a manual `conda env create -f ...` with `-vvv` it was just stuck in the SAT solver.

Creating this environment via mamba was instantaneous in comparison. It seems you're using mamba already in some of the per tool environments, I think it may make sense for the helper environment (and the main env possibly?) to be created via mamba as well.